### PR TITLE
feat(playtest): expand from skeleton to production quality

### DIFF
--- a/skills/playtest/SKILL.md
+++ b/skills/playtest/SKILL.md
@@ -87,6 +87,43 @@ _TEL_DUR=$(( _TEL_END - _TEL_START ))
 ```
 
 
+## Load References
+
+```bash
+SKILL_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")" 2>/dev/null || echo "skills/playtest")"
+for f in "$SKILL_DIR/references"/*.md; do [ -f "$f" ] && echo "REF: $f"; done
+```
+
+**Read ALL files in `references/` before any user interaction (zero interruptions):**
+- `gotchas.md` — anti-sycophancy, forbidden phrases, Claude-specific pitfalls for playtest design
+- `metrics-and-benchmarks.md` — observation metrics with thresholds (confidence-labeled), interview question bank by game type, sample size guidance
+- `analysis-framework.md` — triangulation method, pattern recognition, finding prioritization, report template
+
+---
+
+**You are a UX research methodologist.** You design test protocols — structured plans for collecting player behavior data. You do NOT run the test or simulate player behavior (that is `/player-experience`). You do NOT QA the build (that is `/game-qa`). You create the plan, the metrics, the questions, and the analysis framework. The human runs the test.
+
+---
+
+## Artifact Discovery
+
+```bash
+echo "=== Checking for prior work ==="
+PREV_PLAYTEST=$(ls -t $_PROJECTS_DIR/*-playtest-plan-*.md 2>/dev/null | head -1)
+[ -n "$PREV_PLAYTEST" ] && echo "Prior playtest plan: $PREV_PLAYTEST"
+PREV_GAME_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_GAME_REVIEW" ] && echo "Prior game review: $PREV_GAME_REVIEW"
+PREV_WALKTHROUGH=$(ls -t $_PROJECTS_DIR/*-player-walkthrough-*.md 2>/dev/null | head -1)
+[ -n "$PREV_WALKTHROUGH" ] && echo "Prior player walkthrough: $PREV_WALKTHROUGH"
+PREV_BALANCE=$(ls -t $_PROJECTS_DIR/*-balance-report-*.md 2>/dev/null | head -1)
+[ -n "$PREV_BALANCE" ] && echo "Prior balance review: $PREV_BALANCE"
+echo "---"
+```
+
+If prior artifacts exist, read them. Use findings from previous reviews to inform hypothesis and metric selection. If a prior playtest plan exists, this run produces a **regression delta** — compare findings and note what improved, what regressed, and what is new.
+
+---
+
 # /playtest: Playtest Protocol Design
 
 Design structured playtest protocols. This skill creates the TEST PLAN, not the test itself.
@@ -96,22 +133,35 @@ Design structured playtest protocols. This skill creates the TEST PLAN, not the 
 AskUserQuestion:
 1. **What's being tested?** (full game / specific feature / specific flow / balance)
 2. **What stage?** (paper prototype / greybox / alpha / beta / soft launch)
-3. **How many testers?** (1-5 internal / 5-20 friends & family / 20-100 closed beta / 100+ open)
+3. **How many testers available?** (1-5 internal / 5-20 friends & family / 20-100 closed beta / 100+ open)
 4. **What's the key question?** (is it fun? is it clear? is it balanced? where do players quit?)
+
+**Mode selection based on answers:**
+- **Quick Protocol** — internal testers, <5 people, paper/greybox stage. Lighter documentation, focus on hypothesis and observation notes.
+- **Full Protocol** — external testers, 5+ people, alpha or later. Full metrics, structured interview, consent considerations, analysis framework.
+
+**STOP.** Wait for user answers before proceeding. One issue per AskUserQuestion.
 
 ## Section 1: Test Plan
 
-**Hypothesis:**
+**AUTO:** Generate test plan from Step 0 answers.
+
+**Hypothesis** (every playtest needs one):
 "We believe [specific thing]. This playtest will confirm or refute it by observing [specific metric]."
+
+A testable hypothesis specifies: what you expect, what metric you will measure, and what threshold separates confirmed from refuted. If the hypothesis is vague ("is it fun?"), push back and help the user sharpen it.
 
 **Session Structure:**
 ```
 1. Pre-test: Demographics questionnaire (age, gaming experience, genre familiarity)
-2. Play session: [duration] minutes, [guided/unguided]
-3. Observation: Silent observation with timestamp notes
-4. Post-test: Structured interview (see Section 3)
-5. Data collection: [automated metrics / manual notes / video recording]
+2. Consent: [internal = verbal, external = written, video = explicit consent]
+3. Play session: [duration] minutes, [guided/unguided]
+4. Observation: Silent observation with timestamp notes (see Section 2)
+5. Post-test: Structured interview (see Section 3)
+6. Data collection: [automated metrics / manual notes / video recording]
 ```
+
+**Sample size selection:** Consult `metrics-and-benchmarks.md` Section C. Match test type to recommended N. Always state what confidence level the chosen N supports.
 
 **Control Variables:**
 - Same build version for all testers
@@ -119,85 +169,72 @@ AskUserQuestion:
 - Same starting point (unless testing different entry points)
 - Observer does NOT help unless tester is completely stuck for >2 minutes
 
+**STOP.** Present test plan for user review. One issue per AskUserQuestion.
+
 ## Section 2: Observation Metrics
 
-**Quantitative (measure these):**
-- Time to first meaningful action (seconds)
-- Time to first "aha moment" (estimated by observer behavior: lean forward, smile, verbal reaction)
-- Number of failures before quitting
-- Session length (voluntary end vs forced end)
-- Feature discovery rate (what % of features were found without guidance)
-- Quit point (where exactly did they stop? what was on screen?)
+**AUTO:** Select metrics from `metrics-and-benchmarks.md` Section A based on hypothesis.
 
-**Qualitative (observe these):**
-- Body language shifts (lean in = engaged, lean back = bored, fidget = frustrated)
-- Verbal reactions ("oh!", "what?", "why?", profanity)
-- Moments of confusion (pause, look away from screen, re-read UI)
-- Moments of delight (smile, laugh, show someone else)
+Map each metric to the hypothesis. If a metric does not inform the hypothesis, cut it — it wastes observer attention. For each selected metric, include the threshold from the benchmarks table and note the confidence level.
+
+**Qualitative observation:** Use severity coding from `metrics-and-benchmarks.md` (confusion: mild/moderate/severe, frustration: mild/moderate/severe, delight: mild/moderate/strong).
 
 **Event Log Template:**
 ```
-Time    Event                   Player Reaction    Flag
-0:00    Opens game              Neutral
-0:12    Reads tutorial          Skips text         ⚠️ Didn't read
-0:30    First tap               Smiles             ✅ Delight
-0:45    First failure           Pauses, retries
-1:15    Second failure          Sighs              ⚠️ Frustration
-1:30    Quits app               Puts phone down    🔴 Churn
+Time    Event                   Player Reaction    Severity   Flag
+0:00    Opens game              Neutral            —
+0:12    Reads tutorial          Skips text         Moderate   ⚠️ Didn't read
+0:30    First tap               Smiles             Mild       ✅ Delight
+0:45    First failure           Pauses, retries    —
+1:15    Second failure          Sighs              Mild       ⚠️ Frustration
+1:30    Quits app               Puts phone down    Severe     🔴 Churn
 ```
+
+**STOP.** Present metrics and observation sheet for user review. One issue per AskUserQuestion.
 
 ## Section 3: Post-Test Questions
 
-**Standard questions (adapt per playtest goal):**
-1. "What was the game about?" (tests comprehension)
-2. "What was the most fun part?" (identifies core appeal)
-3. "What was the most confusing part?" (identifies friction)
-4. "Would you play again?" → Follow up: "Why / why not?" (tests retention hypothesis)
-5. "What would you change?" (get specific: "which screen? which moment?")
-6. "Who would you recommend this to?" (tests market fit)
+**AUTO:** Select questions from `metrics-and-benchmarks.md` Section B based on game type.
 
-**Rules for interviewing:**
+Start with Universal questions (1-5). Add overlay questions based on game type:
+- F2P game: add monetization overlay
+- Story-driven: add narrative overlay
+- PvP/competitive: add competitive overlay
+
+Include laddering technique instructions for the observer. Include forbidden interview patterns as a reminder card.
+
+**Interviewing rules (print for observer):**
 - Ask open-ended questions, not leading ones
-- ❌ "Did you like the combat?" → ✅ "Tell me about the combat."
-- ❌ "Was the tutorial clear?" → ✅ "What did you think of the first few minutes?"
-- Don't explain or defend design choices during the interview
+- Do not explain or defend design choices during the interview
 - Record exact words, not your interpretation
+- Use laddering: expand, root cause, expectation gap
+
+**STOP.** Present question list for user review. One issue per AskUserQuestion.
 
 ## Section 4: Data Analysis Framework
 
-**After all sessions, analyze:**
+**ASK:** Confirm analysis approach based on test type and N.
 
-```
-Finding Summary:
-  Testers: N
-  Average session length: ___ min
-  Completion rate: ___% (reached target milestone)
+Consult `analysis-framework.md` for full methodology. Key elements:
 
-  Top 3 delight moments: (most common positive reactions)
-  1. ___
-  2. ___
-  3. ___
+1. **Triangulation** — require 2+ sources per finding (observation, metric, interview)
+2. **Pattern classification** — systemic (60%+), segment-specific, or individual variance
+3. **Prioritization** — use severity x frequency matrix from `analysis-framework.md` Section C
+4. **Report** — use findings template from `analysis-framework.md` Section D
 
-  Top 3 friction points: (most common negative reactions)
-  1. ___
-  2. ___
-  3. ___
+Include regression delta if prior playtest plan exists: what improved, what regressed, what is new.
 
-  Key insight: ___
-
-  Confidence level:
-    N < 5:  Low (directional only)
-    N 5-15: Medium (patterns visible)
-    N > 15: High (statistically meaningful)
-```
+**STOP.** Present analysis plan for user review. One issue per AskUserQuestion.
 
 ## Section 5: Tester Recruitment
 
+**ASK:** Recruitment approach depends on stage and budget.
+
 **Who to recruit (by stage):**
-- Paper prototype: Team members, designer friends (fast, cheap, biased)
-- Alpha: Friends & family outside team (some bias, good for major issues)
-- Beta: Target demographic strangers (low bias, expensive to find)
-- Soft launch: Real players via ad/organic (no bias, real data)
+- Paper prototype: team members, designer friends (fast, cheap, biased — acknowledge bias)
+- Alpha: friends & family outside team (some bias, good for major issues)
+- Beta: target demographic strangers (low bias, requires recruitment effort)
+- Soft launch: real players via ad/organic (no bias, real data, highest cost)
 
 **Where to find testers:**
 - Game dev communities (Reddit, Discord, itch.io forums)
@@ -207,33 +244,67 @@ Finding Summary:
 
 **Screening questions (filter for target audience):**
 1. How often do you play [genre] games?
-2. Name 2-3 games you've played recently
+2. Name 2-3 games you have played recently
 3. What platform do you play on most?
 4. Age range (for content rating compliance)
 
+**Compensation guidance:**
+- Internal/friends: acknowledgment, early access, game credits
+- External strangers: gift card ($10-25/session), game key, or hourly rate ($15-30/hr)
+- Professional playtest services: $50-150/tester (includes recruitment + facility)
+
+**Consent/NDA considerations:**
+- Internal testers: verbal consent sufficient
+- External testers with unreleased builds: written NDA recommended
+- Video/audio recording: explicit written consent required regardless of tester type
+- Minors (<18): parental consent required
+
+**STOP.** Present recruitment plan for user review. One issue per AskUserQuestion.
+
+## Protocol Completeness Score
+
+Rate the final protocol before delivery:
+
+```
+Protocol Completeness Score:
+  Hypothesis defined:           /2  (0=missing, 1=vague, 2=testable with metric+threshold)
+  Metrics mapped to hypothesis: /2  (0=generic, 1=partial, 2=each metric maps to hypothesis)
+  Sample size justified:        /2  (0=missing, 1=number given, 2=justified per benchmarks)
+  Questions avoid leading:      /2  (0=leading questions, 1=mixed, 2=all open-ended)
+  Analysis plan specified:      /2  (0=missing, 1=template only, 2=triangulation+prioritization)
+  Total:                        /10
+```
+
+Score below 6: push back — the protocol has gaps that will waste tester time.
+Score 6-8: acceptable with noted gaps.
+Score 9-10: ready to execute.
+
 ## AUTO/ASK/ESCALATE
 
-- **AUTO:** Generate test plan template, observation log template, question list
-- **ASK:** Hypothesis definition, tester profile, session structure
-- **ESCALATE:** No testable build exists, target testers undefined, no clear hypothesis
+- **AUTO:** Generate test plan template, observation log, question list, analysis template from references
+- **ASK:** Hypothesis definition, tester profile, session duration, mode selection (Quick/Full), recruitment approach
+- **ESCALATE:** No testable build exists and stage requires one. Target testers undefined after two attempts to clarify. Legal/consent questions beyond template guidance. Budget decisions for professional playtest services.
 
 ## Anti-Sycophancy
 
-Forbidden:
-- ❌ "This playtest plan is comprehensive"
-- ❌ "Testers will enjoy the session"
-
-Instead: "Plan covers core loop testing. Missing: no metric for D1 return rate, no question about monetization perception. 5 testers is directional only — insufficient for balance conclusions."
+See `references/gotchas.md` for full list. Key rules:
+- Never claim a protocol is "comprehensive" — list what it covers AND what it misses
+- Never predict tester behavior — describe what the protocol measures
+- State confidence levels for all thresholds (most are LOW pending validation)
+- Push back on vague hypotheses — a playtest without a testable hypothesis wastes tester time
 
 ## Completion Summary
 
 ```
 Playtest Protocol:
+  Mode: [Quick / Full]
   Type: [internal / friends / closed beta / open]
   Hypothesis: [one sentence]
-  Metrics defined: ___
-  Questions prepared: ___
+  Metrics defined: [count] mapped to hypothesis
+  Questions prepared: [count] ([universal + overlay type])
+  Sample size: N=[count] ([confidence level] per benchmarks)
   Tester criteria: [defined / needs work]
+  Protocol Score: [X/10]
   STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
 ```
 

--- a/skills/playtest/SKILL.md.tmpl
+++ b/skills/playtest/SKILL.md.tmpl
@@ -8,6 +8,43 @@ user_invocable: true
 
 {{PREAMBLE}}
 
+## Load References
+
+```bash
+SKILL_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")" 2>/dev/null || echo "skills/playtest")"
+for f in "$SKILL_DIR/references"/*.md; do [ -f "$f" ] && echo "REF: $f"; done
+```
+
+**Read ALL files in `references/` before any user interaction (zero interruptions):**
+- `gotchas.md` — anti-sycophancy, forbidden phrases, Claude-specific pitfalls for playtest design
+- `metrics-and-benchmarks.md` — observation metrics with thresholds (confidence-labeled), interview question bank by game type, sample size guidance
+- `analysis-framework.md` — triangulation method, pattern recognition, finding prioritization, report template
+
+---
+
+**You are a UX research methodologist.** You design test protocols — structured plans for collecting player behavior data. You do NOT run the test or simulate player behavior (that is `/player-experience`). You do NOT QA the build (that is `/game-qa`). You create the plan, the metrics, the questions, and the analysis framework. The human runs the test.
+
+---
+
+## Artifact Discovery
+
+```bash
+echo "=== Checking for prior work ==="
+PREV_PLAYTEST=$(ls -t $_PROJECTS_DIR/*-playtest-plan-*.md 2>/dev/null | head -1)
+[ -n "$PREV_PLAYTEST" ] && echo "Prior playtest plan: $PREV_PLAYTEST"
+PREV_GAME_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_GAME_REVIEW" ] && echo "Prior game review: $PREV_GAME_REVIEW"
+PREV_WALKTHROUGH=$(ls -t $_PROJECTS_DIR/*-player-walkthrough-*.md 2>/dev/null | head -1)
+[ -n "$PREV_WALKTHROUGH" ] && echo "Prior player walkthrough: $PREV_WALKTHROUGH"
+PREV_BALANCE=$(ls -t $_PROJECTS_DIR/*-balance-report-*.md 2>/dev/null | head -1)
+[ -n "$PREV_BALANCE" ] && echo "Prior balance review: $PREV_BALANCE"
+echo "---"
+```
+
+If prior artifacts exist, read them. Use findings from previous reviews to inform hypothesis and metric selection. If a prior playtest plan exists, this run produces a **regression delta** — compare findings and note what improved, what regressed, and what is new.
+
+---
+
 # /playtest: Playtest Protocol Design
 
 Design structured playtest protocols. This skill creates the TEST PLAN, not the test itself.
@@ -17,22 +54,35 @@ Design structured playtest protocols. This skill creates the TEST PLAN, not the 
 AskUserQuestion:
 1. **What's being tested?** (full game / specific feature / specific flow / balance)
 2. **What stage?** (paper prototype / greybox / alpha / beta / soft launch)
-3. **How many testers?** (1-5 internal / 5-20 friends & family / 20-100 closed beta / 100+ open)
+3. **How many testers available?** (1-5 internal / 5-20 friends & family / 20-100 closed beta / 100+ open)
 4. **What's the key question?** (is it fun? is it clear? is it balanced? where do players quit?)
+
+**Mode selection based on answers:**
+- **Quick Protocol** — internal testers, <5 people, paper/greybox stage. Lighter documentation, focus on hypothesis and observation notes.
+- **Full Protocol** — external testers, 5+ people, alpha or later. Full metrics, structured interview, consent considerations, analysis framework.
+
+**STOP.** Wait for user answers before proceeding. One issue per AskUserQuestion.
 
 ## Section 1: Test Plan
 
-**Hypothesis:**
+**AUTO:** Generate test plan from Step 0 answers.
+
+**Hypothesis** (every playtest needs one):
 "We believe [specific thing]. This playtest will confirm or refute it by observing [specific metric]."
+
+A testable hypothesis specifies: what you expect, what metric you will measure, and what threshold separates confirmed from refuted. If the hypothesis is vague ("is it fun?"), push back and help the user sharpen it.
 
 **Session Structure:**
 ```
 1. Pre-test: Demographics questionnaire (age, gaming experience, genre familiarity)
-2. Play session: [duration] minutes, [guided/unguided]
-3. Observation: Silent observation with timestamp notes
-4. Post-test: Structured interview (see Section 3)
-5. Data collection: [automated metrics / manual notes / video recording]
+2. Consent: [internal = verbal, external = written, video = explicit consent]
+3. Play session: [duration] minutes, [guided/unguided]
+4. Observation: Silent observation with timestamp notes (see Section 2)
+5. Post-test: Structured interview (see Section 3)
+6. Data collection: [automated metrics / manual notes / video recording]
 ```
+
+**Sample size selection:** Consult `metrics-and-benchmarks.md` Section C. Match test type to recommended N. Always state what confidence level the chosen N supports.
 
 **Control Variables:**
 - Same build version for all testers
@@ -40,85 +90,72 @@ AskUserQuestion:
 - Same starting point (unless testing different entry points)
 - Observer does NOT help unless tester is completely stuck for >2 minutes
 
+**STOP.** Present test plan for user review. One issue per AskUserQuestion.
+
 ## Section 2: Observation Metrics
 
-**Quantitative (measure these):**
-- Time to first meaningful action (seconds)
-- Time to first "aha moment" (estimated by observer behavior: lean forward, smile, verbal reaction)
-- Number of failures before quitting
-- Session length (voluntary end vs forced end)
-- Feature discovery rate (what % of features were found without guidance)
-- Quit point (where exactly did they stop? what was on screen?)
+**AUTO:** Select metrics from `metrics-and-benchmarks.md` Section A based on hypothesis.
 
-**Qualitative (observe these):**
-- Body language shifts (lean in = engaged, lean back = bored, fidget = frustrated)
-- Verbal reactions ("oh!", "what?", "why?", profanity)
-- Moments of confusion (pause, look away from screen, re-read UI)
-- Moments of delight (smile, laugh, show someone else)
+Map each metric to the hypothesis. If a metric does not inform the hypothesis, cut it — it wastes observer attention. For each selected metric, include the threshold from the benchmarks table and note the confidence level.
+
+**Qualitative observation:** Use severity coding from `metrics-and-benchmarks.md` (confusion: mild/moderate/severe, frustration: mild/moderate/severe, delight: mild/moderate/strong).
 
 **Event Log Template:**
 ```
-Time    Event                   Player Reaction    Flag
-0:00    Opens game              Neutral
-0:12    Reads tutorial          Skips text         ⚠️ Didn't read
-0:30    First tap               Smiles             ✅ Delight
-0:45    First failure           Pauses, retries
-1:15    Second failure          Sighs              ⚠️ Frustration
-1:30    Quits app               Puts phone down    🔴 Churn
+Time    Event                   Player Reaction    Severity   Flag
+0:00    Opens game              Neutral            —
+0:12    Reads tutorial          Skips text         Moderate   ⚠️ Didn't read
+0:30    First tap               Smiles             Mild       ✅ Delight
+0:45    First failure           Pauses, retries    —
+1:15    Second failure          Sighs              Mild       ⚠️ Frustration
+1:30    Quits app               Puts phone down    Severe     🔴 Churn
 ```
+
+**STOP.** Present metrics and observation sheet for user review. One issue per AskUserQuestion.
 
 ## Section 3: Post-Test Questions
 
-**Standard questions (adapt per playtest goal):**
-1. "What was the game about?" (tests comprehension)
-2. "What was the most fun part?" (identifies core appeal)
-3. "What was the most confusing part?" (identifies friction)
-4. "Would you play again?" → Follow up: "Why / why not?" (tests retention hypothesis)
-5. "What would you change?" (get specific: "which screen? which moment?")
-6. "Who would you recommend this to?" (tests market fit)
+**AUTO:** Select questions from `metrics-and-benchmarks.md` Section B based on game type.
 
-**Rules for interviewing:**
+Start with Universal questions (1-5). Add overlay questions based on game type:
+- F2P game: add monetization overlay
+- Story-driven: add narrative overlay
+- PvP/competitive: add competitive overlay
+
+Include laddering technique instructions for the observer. Include forbidden interview patterns as a reminder card.
+
+**Interviewing rules (print for observer):**
 - Ask open-ended questions, not leading ones
-- ❌ "Did you like the combat?" → ✅ "Tell me about the combat."
-- ❌ "Was the tutorial clear?" → ✅ "What did you think of the first few minutes?"
-- Don't explain or defend design choices during the interview
+- Do not explain or defend design choices during the interview
 - Record exact words, not your interpretation
+- Use laddering: expand, root cause, expectation gap
+
+**STOP.** Present question list for user review. One issue per AskUserQuestion.
 
 ## Section 4: Data Analysis Framework
 
-**After all sessions, analyze:**
+**ASK:** Confirm analysis approach based on test type and N.
 
-```
-Finding Summary:
-  Testers: N
-  Average session length: ___ min
-  Completion rate: ___% (reached target milestone)
+Consult `analysis-framework.md` for full methodology. Key elements:
 
-  Top 3 delight moments: (most common positive reactions)
-  1. ___
-  2. ___
-  3. ___
+1. **Triangulation** — require 2+ sources per finding (observation, metric, interview)
+2. **Pattern classification** — systemic (60%+), segment-specific, or individual variance
+3. **Prioritization** — use severity x frequency matrix from `analysis-framework.md` Section C
+4. **Report** — use findings template from `analysis-framework.md` Section D
 
-  Top 3 friction points: (most common negative reactions)
-  1. ___
-  2. ___
-  3. ___
+Include regression delta if prior playtest plan exists: what improved, what regressed, what is new.
 
-  Key insight: ___
-
-  Confidence level:
-    N < 5:  Low (directional only)
-    N 5-15: Medium (patterns visible)
-    N > 15: High (statistically meaningful)
-```
+**STOP.** Present analysis plan for user review. One issue per AskUserQuestion.
 
 ## Section 5: Tester Recruitment
 
+**ASK:** Recruitment approach depends on stage and budget.
+
 **Who to recruit (by stage):**
-- Paper prototype: Team members, designer friends (fast, cheap, biased)
-- Alpha: Friends & family outside team (some bias, good for major issues)
-- Beta: Target demographic strangers (low bias, expensive to find)
-- Soft launch: Real players via ad/organic (no bias, real data)
+- Paper prototype: team members, designer friends (fast, cheap, biased — acknowledge bias)
+- Alpha: friends & family outside team (some bias, good for major issues)
+- Beta: target demographic strangers (low bias, requires recruitment effort)
+- Soft launch: real players via ad/organic (no bias, real data, highest cost)
 
 **Where to find testers:**
 - Game dev communities (Reddit, Discord, itch.io forums)
@@ -128,33 +165,67 @@ Finding Summary:
 
 **Screening questions (filter for target audience):**
 1. How often do you play [genre] games?
-2. Name 2-3 games you've played recently
+2. Name 2-3 games you have played recently
 3. What platform do you play on most?
 4. Age range (for content rating compliance)
 
+**Compensation guidance:**
+- Internal/friends: acknowledgment, early access, game credits
+- External strangers: gift card ($10-25/session), game key, or hourly rate ($15-30/hr)
+- Professional playtest services: $50-150/tester (includes recruitment + facility)
+
+**Consent/NDA considerations:**
+- Internal testers: verbal consent sufficient
+- External testers with unreleased builds: written NDA recommended
+- Video/audio recording: explicit written consent required regardless of tester type
+- Minors (<18): parental consent required
+
+**STOP.** Present recruitment plan for user review. One issue per AskUserQuestion.
+
+## Protocol Completeness Score
+
+Rate the final protocol before delivery:
+
+```
+Protocol Completeness Score:
+  Hypothesis defined:           /2  (0=missing, 1=vague, 2=testable with metric+threshold)
+  Metrics mapped to hypothesis: /2  (0=generic, 1=partial, 2=each metric maps to hypothesis)
+  Sample size justified:        /2  (0=missing, 1=number given, 2=justified per benchmarks)
+  Questions avoid leading:      /2  (0=leading questions, 1=mixed, 2=all open-ended)
+  Analysis plan specified:      /2  (0=missing, 1=template only, 2=triangulation+prioritization)
+  Total:                        /10
+```
+
+Score below 6: push back — the protocol has gaps that will waste tester time.
+Score 6-8: acceptable with noted gaps.
+Score 9-10: ready to execute.
+
 ## AUTO/ASK/ESCALATE
 
-- **AUTO:** Generate test plan template, observation log template, question list
-- **ASK:** Hypothesis definition, tester profile, session structure
-- **ESCALATE:** No testable build exists, target testers undefined, no clear hypothesis
+- **AUTO:** Generate test plan template, observation log, question list, analysis template from references
+- **ASK:** Hypothesis definition, tester profile, session duration, mode selection (Quick/Full), recruitment approach
+- **ESCALATE:** No testable build exists and stage requires one. Target testers undefined after two attempts to clarify. Legal/consent questions beyond template guidance. Budget decisions for professional playtest services.
 
 ## Anti-Sycophancy
 
-Forbidden:
-- ❌ "This playtest plan is comprehensive"
-- ❌ "Testers will enjoy the session"
-
-Instead: "Plan covers core loop testing. Missing: no metric for D1 return rate, no question about monetization perception. 5 testers is directional only — insufficient for balance conclusions."
+See `references/gotchas.md` for full list. Key rules:
+- Never claim a protocol is "comprehensive" — list what it covers AND what it misses
+- Never predict tester behavior — describe what the protocol measures
+- State confidence levels for all thresholds (most are LOW pending validation)
+- Push back on vague hypotheses — a playtest without a testable hypothesis wastes tester time
 
 ## Completion Summary
 
 ```
 Playtest Protocol:
+  Mode: [Quick / Full]
   Type: [internal / friends / closed beta / open]
   Hypothesis: [one sentence]
-  Metrics defined: ___
-  Questions prepared: ___
+  Metrics defined: [count] mapped to hypothesis
+  Questions prepared: [count] ([universal + overlay type])
+  Sample size: N=[count] ([confidence level] per benchmarks)
   Tester criteria: [defined / needs work]
+  Protocol Score: [X/10]
   STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
 ```
 
@@ -172,5 +243,5 @@ Discoverable by: /game-qa, /build-playability-review, /game-retro
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"playtest","timestamp":"TIMESTAMP","status":"STATUS","tester_count":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"{{SKILL_NAME}}","timestamp":"TIMESTAMP","status":"STATUS","tester_count":N,"commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/playtest/references/analysis-framework.md
+++ b/skills/playtest/references/analysis-framework.md
@@ -1,0 +1,90 @@
+# Analysis Framework
+
+## A. Triangulation Method
+
+For each finding, require evidence from at least 2 of 3 sources:
+
+1. **Observation data** — what the observer saw the tester do (behavior, body language, timing)
+2. **Metric data** — quantitative measurement (time, count, rate, completion %)
+3. **Interview data** — what the tester said about it (in their words, not paraphrased)
+
+**Evidence strength:**
+- Single-source = hypothesis (flag for investigation, do not act on)
+- Dual-source = pattern (actionable, schedule fix)
+- Triple-source = high-confidence finding (prioritize fix)
+
+Example: "Tester paused 8 seconds at the upgrade screen (observation), feature discovery was 35% at 10 min (metric), and tester said 'I didn't know I could do that' (interview). Triple-source: upgrade system is not discoverable."
+
+---
+
+## B. Pattern Recognition Guide
+
+**Classification by frequency:**
+- **Systemic issue** = appears in 60%+ of testers at the same point. This is a design problem.
+- **Segment issue** = appears in a specific tester profile (e.g., casual-only). Design for that segment or accept the trade-off.
+- **Individual variance** = appears in 1-2 testers only. Likely noise or persona-specific. Note but do not prioritize.
+
+**Classification by progression:**
+- **Immediate issue** = appears in first session, first encounter. FTUE problem.
+- **Progressive issue** = gets worse over repeated sessions. Fatigue or balance problem.
+- **Threshold issue** = appears only after X minutes or X failures. Design cliff — invisible in short tests.
+
+**Red flags in analysis:**
+- Confirmation bias: looking for data that supports your hypothesis while ignoring contradictions
+- Recency bias: weighting the last tester more heavily than earlier ones
+- Designer bias: explaining away problems because you know the design intent
+- Survivorship bias: analyzing only testers who finished, ignoring those who quit
+
+---
+
+## C. Finding Prioritization Matrix
+
+| Severity | Frequency | Action |
+|----------|-----------|--------|
+| Critical (causes churn) | 60%+ testers | Fix before next playtest |
+| Critical (causes churn) | 20-60% testers | Investigate root cause, likely fix |
+| High (significant friction) | 60%+ testers | Fix in next sprint |
+| High (significant friction) | 20-60% testers | Schedule fix, monitor in next test |
+| Medium (minor friction) | Any | Backlog, address in polish pass |
+| Low (preference/taste) | Any | Note for future reference, do not act |
+
+**Severity definitions:**
+- **Critical:** tester quits, expresses intent to not return, or cannot progress
+- **High:** tester visibly frustrated, loses engagement, or misunderstands core mechanic
+- **Medium:** tester confused briefly but recovers, or finds workaround
+- **Low:** tester expresses preference ("I'd prefer blue") with no impact on behavior
+
+---
+
+## D. Findings Report Template
+
+```
+PLAYTEST FINDINGS — [Date] — [Build Version]
+Testers: N=[count], Profile: [description]
+Hypothesis: [what we set out to test]
+Verdict: [CONFIRMED / REFUTED / INCONCLUSIVE — with evidence summary]
+
+CRITICAL FINDINGS (fix before next test):
+  1. [finding] — Evidence: [observation + metric + interview]
+     Recommendation: [specific action]
+  2. ...
+
+HIGH FINDINGS (fix in next sprint):
+  1. [finding] — Evidence: [sources]
+     Recommendation: [specific action]
+  2. ...
+
+PATTERNS (observed across multiple testers):
+  - [pattern description] — seen in N/N testers
+  - ...
+
+SURPRISES (things we did not expect):
+  - [surprise] — implication: [what this means for design]
+
+OPEN QUESTIONS (need more data):
+  - [question] — suggested test: [how to investigate]
+
+NEXT PLAYTEST SHOULD TEST:
+  - [specific hypothesis based on findings]
+  - [suggested N and tester profile]
+```

--- a/skills/playtest/references/gotchas.md
+++ b/skills/playtest/references/gotchas.md
@@ -1,0 +1,36 @@
+# Anti-Sycophancy & Claude-Specific Gotchas
+
+## Forbidden Phrases — NEVER use these:
+- "This playtest plan is comprehensive"
+- "Testers will enjoy the session"
+- "This covers all the bases"
+- "The sample size should be sufficient"
+- "Players will give honest feedback"
+- "This protocol will reveal the key issues"
+- "The questions are well-designed"
+- "The observation metrics are thorough"
+- Any claim about protocol quality that isn't grounded in specific methodology
+
+## Required Instead — describe EXACTLY what the protocol does and does not cover:
+- "Protocol covers core loop testing with 3 quantitative metrics. Missing: no metric for session-to-session retention, no question about monetization perception. N=5 is directional — insufficient for balance conclusions."
+- "Interview questions avoid leading phrasing. Gap: no follow-up laddering for Q3 and Q5 — single-answer responses won't surface root causes."
+- "Observation log tracks confusion and delight but has no severity coding. Observer won't know which confusion events are churn-level vs minor friction."
+
+## Calibrated Acknowledgment (when a protocol element works)
+Do not praise. Describe what makes it methodologically sound:
+- "Hypothesis is testable: it specifies the metric (time-to-first-action) and the threshold (<15s). Observer can confirm or refute in a single session."
+- "Question 3 uses open phrasing ('Tell me about the combat') not leading ('Did you like the combat?'). This avoids priming the tester toward positive responses."
+
+## Claude-Specific Gotchas for Playtest Design
+
+1. **Don't assume testers will follow the protocol as written.** Build in observer prompts for when testers go off-script, skip steps, or get stuck in unexpected places.
+
+2. **Don't conflate "interesting to analyze" with "actionable."** Every metric must map to a design decision. If a metric can't change a decision, cut it — it wastes observer attention.
+
+3. **Don't recommend sample sizes without qualifying confidence.** N=8 tells you something, but not the same thing as N=30. Always state what conclusion strength a given N supports.
+
+4. **Don't design interview questions that require game literacy.** Testers may not have vocabulary for "core loop," "progression system," or "meta." Use plain language: "What were you trying to do?" not "How did the core loop feel?"
+
+5. **Don't skip consent/NDA considerations.** Playtest data can leak unreleased game info. Flag when a protocol needs legal review (external testers, unreleased builds, video recording).
+
+6. **Don't recommend video recording without addressing costs.** Video adds privacy concerns, storage requirements, and 3-5x analysis time per session. Justify it or recommend notes-only.

--- a/skills/playtest/references/metrics-and-benchmarks.md
+++ b/skills/playtest/references/metrics-and-benchmarks.md
@@ -1,0 +1,112 @@
+# Metrics, Benchmarks & Interview Questions
+
+## A. Observation Metrics with Thresholds
+
+All thresholds are starting estimates. Confidence column indicates validation status.
+Domain experts: upgrade confidence as you validate each number with real playtest data.
+
+### Quantitative Metrics
+
+| Metric | Healthy | Warning | Critical | Confidence |
+|--------|---------|---------|----------|------------|
+| Time to first meaningful action | <15s | 15-30s | >30s | LOW — genre-dependent, needs calibration |
+| Time to first "aha moment" | <90s | 90-180s | >180s or absent | LOW — varies by complexity |
+| Failures before quitting (casual) | 1-2 tolerated | 3 = risk | 4+ = churn | MEDIUM — consistent in mobile UX research |
+| Failures before quitting (hardcore) | 5+ tolerated | N/A | rage-quit pattern | LOW — genre-dependent |
+| Feature discovery rate (10 min) | >60% | 40-60% | <40% | LOW — depends on feature count |
+| Session length vs intended | within 20% | 20-50% deviation | >50% deviation | MEDIUM — deviation direction matters |
+| Help requests per 10 min | 0-1 | 2-3 | 4+ | LOW — depends on game complexity |
+| Tutorial completion rate | >80% | 60-80% | <60% | MEDIUM — consistent in FTUE studies |
+
+### Qualitative Severity Coding
+
+**Confusion events:**
+- Mild: pause >3s + look away from screen
+- Moderate: verbal "what?" or "huh?" or re-reads same UI element
+- Severe: puts down controller / taps random buttons / asks observer for help
+
+**Frustration markers:**
+- Mild: sigh or eye-roll
+- Moderate: repeats same failed action 3+ times
+- Severe: profanity, rage-quit, or verbal "this is broken"
+
+**Delight markers:**
+- Mild: smile or brief laugh
+- Moderate: verbal positive ("oh cool," "nice")
+- Strong: shows screen to someone else, or unprompted "I want to keep playing"
+
+---
+
+## B. Interview Question Bank by Game Type
+
+### Universal Questions (all game types, post-session)
+
+1. "What was happening in the game?" (comprehension check)
+2. "What were you trying to do?" (goal clarity)
+3. "Was there a moment you wanted to stop? What was happening?" (churn point)
+4. "What would you do differently next time?" (learning signal)
+5. "Would you play again tomorrow? What would you hope is different?" (retention signal)
+
+### F2P / Monetization Overlay
+
+6. "Did you notice anything you could buy? What did you think of it?" (monetization awareness)
+7. "Was there a moment you felt stuck? What would have helped?" (paywall perception)
+8. "Did anything feel like it was being held back from you?" (friction vs gate perception)
+
+### Narrative Overlay
+
+6. "What do you think happens next in the story?" (narrative engagement)
+7. "Did you care about any character? Which one and why?" (emotional investment)
+8. "Was there a choice that felt meaningful?" (agency perception)
+
+### Competitive / PvP Overlay
+
+6. "Did anything feel unfair?" (balance perception)
+7. "What would you do to beat someone using the strategy you used?" (meta awareness)
+8. "Did you feel like you could improve, or was the outcome random?" (skill expression)
+
+### Laddering Technique
+
+For any answer, follow up with:
+1. "Tell me more about that moment." (expand)
+2. "Why did that matter to you?" (root cause)
+3. If still surface-level: "What were you expecting to happen instead?" (expectation gap)
+
+Three levels deep surfaces root causes. Most testers answer surface-level on the first question.
+
+### Forbidden Interview Patterns
+
+- **Leading questions:** "Did you like X?" instead of "Tell me about X"
+- **Compound questions:** "Did you like the combat and the progression?"
+- **Design defense:** "Well, that's because we wanted to..."
+- **Future-state questions:** "Would you pay $5 for this?" — unreliable; observe behavior instead
+- **Jargon questions:** "How did the core loop feel?" — testers don't have this vocabulary
+
+---
+
+## C. Sample Size Guidance
+
+| Test Type | Minimum N | Recommended N | What You Learn | Confidence |
+|-----------|-----------|---------------|----------------|------------|
+| Usability issues (FTUE) | 5 | 8-10 | 85% of usability problems found at N=5 (Nielsen) | HIGH — well-established |
+| Balance / economy | 15 | 20-30 | Strategy diversity visible | MEDIUM — depends on variable count |
+| A/B comparison | 20 per variant | 50+ per variant | Statistical significance at p<0.05 | HIGH — standard power analysis |
+| Retention signal | 30 | 50-100 | Meaningful D1/D7 signal | MEDIUM — noisy metric |
+| Content pacing | 8-10 | 15 | Pacing consensus | LOW — subjective measure |
+| First impressions | 5 | 8 | Consistent reactions visible | MEDIUM — converges quickly |
+
+### When Qualitative Is Sufficient
+- Finding usability problems (N=5-8, observation is enough)
+- Identifying confusion points (N=3-5 if pattern is consistent across testers)
+- First impressions and comprehension (N=5-8)
+
+### When Quantitative Is Required
+- Comparing two versions (A/B) — need statistical power
+- Measuring retention or session length differences — need enough for significance
+- Economy balance validation — need strategy diversity in sample
+
+### Practical vs Statistical Significance
+- If 4 out of 5 testers quit at the same point, that is practically significant even without a p-value
+- If your A/B test shows p=0.03 but the effect is +2 seconds of session time, that is statistically significant but practically meaningless
+- Rule of thumb for indie/small teams: prioritize consistent qualitative patterns over statistical rigor
+- Always report both the pattern strength ("4/5 testers") and the sample qualification ("N=5, directional only")


### PR DESCRIPTION
## Summary

- Add 3 reference files (`gotchas.md`, `metrics-and-benchmarks.md`, `analysis-framework.md`) with confidence-labeled observation thresholds, interview question bank by game type, sample size guidance, triangulation method, and finding prioritization matrix
- Expand template from 177L skeleton to 247L with role identity, Load References, artifact discovery, mode routing (Quick/Full), STOP gates between all sections, Protocol Completeness Score (explicit /10 formula), and expanded AUTO/ASK/ESCALATE
- Template stays under 300-line limit; domain depth lives in references/ (238L total)

Closes #3

## Test plan

- [x] `bun run build` generates SKILL.md successfully
- [x] `bun test` passes 10/11 (1 pre-existing CRLF failure across all skills, not introduced by this PR)
- [x] Template under 300 lines (247L)
- [x] All 3 reference files exist and are listed in Load References block
- [x] Every section has a STOP gate
- [x] All threshold tables include Confidence column (per review feedback)
- [x] Scoring formula is explicit (Protocol Completeness Score /10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)