### PR TITLE
feat(game-visual-qa): expand skeleton with visual thresholds and animation standards

### DIFF
--- a/skills/game-visual-qa/SKILL.md
+++ b/skills/game-visual-qa/SKILL.md
@@ -87,9 +87,24 @@ _TEL_DUR=$(( _TEL_END - _TEL_START ))
 ```
 
 
+## Load References
+
+```bash
+echo "=== Loading game-visual-qa reference files ==="
+ls references/*.md 2>/dev/null | while read f; do echo "  $f"; done
+```
+
+**Read ALL `references/` files NOW before any user interaction.** They contain visual thresholds, animation standards, platform requirements, scoring model, and gotchas. Zero interruption — load everything upfront.
+
+## Scope Boundaries
+
+- `/game-visual-qa`: Reviews the **visual output** of a built game (what the player sees on screen)
+- `/asset-review`: Reviews **asset files** in the project (formats, sizes, naming, pipeline)
+- `/game-qa` Section 3: Quick visual pass as part of full QA — use `/game-visual-qa` for deep visual-only review
+
 # /game-visual-qa: Visual Quality Assurance
 
-Systematic visual review of game screens, UI, animations, and art consistency.
+Systematic visual review of game screens, UI, animations, and art consistency. Apply `references/gotchas.md` throughout the entire review.
 
 ## Step 0: Visual Context
 
@@ -99,17 +114,35 @@ AskUserQuestion: What are we reviewing?
 - C) UI-only review
 - D) Animation review
 
-Establish: Art style reference (art bible? moodboard? reference game?), target resolution, target platforms.
+Establish:
+1. **Art style reference** — art bible, moodboard, or reference game?
+2. **Art style classification**: A) Pixel art, B) Hand-drawn/2D, C) 3D stylized, D) 3D realistic, E) Mixed media
+   - Style classification affects which thresholds from `references/animation-standards.md` apply
+3. **Target resolution** and **target platforms** (determines thresholds from `references/platform-requirements.md`)
+4. **Build status** — final art, WIP, or placeholder? (See `references/gotchas.md` Scope Traps)
+
+**STOP.** Confirm context before proceeding.
 
 ## Section 1: First Impression (weight: 10%)
+
+**AI confidence: 25% — first impressions are inherently subjective. This section is a prompt for human evaluation, not an AI judgment.**
 
 1-second gut reaction:
 - Professional or amateur?
 - Cohesive or inconsistent?
 - Clear or cluttered?
-- Score: 0-10
+
+Forcing questions:
+- "If you saw this screenshot on a store page with no title, would you wishlist it?"
+- "What genre and quality tier does the art communicate in the first second?"
+
+Score using the per-section scoring from `references/scoring.md`. Section 1 Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 2: Art Style Consistency (weight: 20%)
+
+**AI confidence: 35% — style evaluation requires art direction context. Flag inconsistencies but defer final judgment to the user.**
 
 - Color palette adherence — Do all elements use the same palette?
 - Line weight consistency — Outlines same thickness across all assets?
@@ -118,51 +151,92 @@ Establish: Art style reference (art bible? moodboard? reference game?), target r
 - Environmental scale — Objects correct size relative to characters?
 - Effect style — Particles/VFX match the art style? (realistic effects in pixel art = mismatch)
 
-Score: Start at 10, each inconsistency: high-impact -2, medium -1, low -0.5
+Forcing questions:
+- "Show me the 2 most visually different screens side by side. Are they from the same game?"
+- "If you removed the HUD, could you identify which game this screenshot is from?"
+
+Classify severity per issue using `references/scoring.md` severity definitions. Score: Start at 10, deduct per issue found.
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 3: UI Polish (weight: 20%)
 
-- Alignment — Elements on grid? Consistent margins?
-- Typography — Font hierarchy clear? Readable at target resolution?
+**AI confidence: 65% — most UI checks are measurable against `references/visual-thresholds.md`.**
+
+- Alignment — Elements on grid? Consistent margins? (see `references/visual-thresholds.md` Pixel Alignment)
+- Typography — Font hierarchy clear? Readable at target resolution? (see font size minimums)
 - Color meaning — Consistent (red = damage, green = heal) across ALL screens?
-- Touch/click targets — Minimum 44px on mobile? No overlapping targets?
+- Touch/click targets — Meet platform minimums from `references/visual-thresholds.md`?
 - States — Hover, pressed, disabled, loading states all designed?
 - Transitions — Screens transition smoothly? No jarring cuts?
 
-Score: Same deduction model.
+Forcing questions:
+- "Navigate the 3 most-used menus using only the intended input method. Any hesitation point?"
+- "Screenshot every screen with text. Is the font hierarchy identical across all of them?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 4: Animation Quality (weight: 20%)
 
-- Frame rate — Smooth at target FPS? Any judder?
-- Anticipation — Actions have wind-up? (makes them readable)
-- Follow-through — Actions have recovery? (makes them feel weighty)
+**AI confidence: 60% — frame counts and blend times are measurable; feel and weight are subjective.**
+
+- Frame count — Meets guidelines from `references/animation-standards.md` for the art style?
+- Anticipation — Actions have wind-up >= 2 frames? (makes them readable)
+- Follow-through — Actions have recovery >= 2 frames? (makes them feel weighty)
 - Timing — Fast actions feel fast? Heavy actions feel heavy?
-- Blending — Transitions between animations smooth? No T-pose flashes?
+- Blending — Transition times within targets from `references/animation-standards.md`? No T-pose flashes?
 - Idle — Characters alive when not acting? Breathing, blinking, shifting weight?
 
-Score: Same deduction model.
+Forcing questions:
+- "Play the most common action at 0.25x speed. Is every frame intentional?"
+- "Watch a character stand idle for 30 seconds. Do they feel alive?"
+
+Check against common animation bugs in `references/animation-standards.md`. Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 5: Screen Adaptation (weight: 15%)
 
-- Aspect ratios — 16:9, 18:9, 21:9, 4:3 — nothing cut off?
-- Safe zone — Critical UI elements within safe area?
-- Scaling — Text readable on smallest target screen?
-- Notch/cutout — Content not hidden behind camera notch?
+**AI confidence: 75% — safe zones and aspect ratios are fully measurable against `references/platform-requirements.md`.**
+
+- Aspect ratios — Test at widest and narrowest supported ratio. Nothing cut off?
+- Safe zone — Critical UI within safe area per `references/platform-requirements.md`?
+- Scaling — Text readable on smallest target screen? (check against `references/visual-thresholds.md`)
+- Notch/cutout — Content not hidden behind camera notch? Uses platform safe area APIs?
 - Orientation — If mobile: landscape/portrait handled correctly?
 
-Score: Same deduction model.
+Forcing questions:
+- "Screenshot the main gameplay screen at 4:3 (iPad) and 19.5:9 (iPhone). What breaks?"
+- "Can you read all HUD text on the smallest target device at arm's length?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 6: Performance Visual (weight: 15%)
+
+**AI confidence: 70% — most performance visuals are observable, though root causes may not be.**
 
 - Texture quality — No blurry textures at expected view distance?
 - Pop-in — LOD transitions visible? Asset streaming visible?
 - Z-fighting — Overlapping surfaces flickering?
 - Overdraw — Excessive transparency layers? (check with wireframe)
 - Particle budget — Particle effects reasonable? No FPS drop during effects?
+- Frame pacing — Consistent frame delivery? (see FPS targets in `references/animation-standards.md`)
 
-Score: Same deduction model.
+Forcing questions:
+- "Run through the busiest scene in the game. Any visual hitches or pop-in?"
+- "Toggle between lowest and highest quality settings. What changes are visible?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Scoring
+
+Calculate weighted final score using formula from `references/scoring.md`:
 
 ```
 Visual QA Score:
@@ -176,27 +250,40 @@ Visual QA Score:
   WEIGHTED TOTAL:         _/10
 ```
 
+Interpret using score ranges from `references/scoring.md`: 90-100 ship-ready, 75-89 shippable with known issues, 60-74 needs work, below 60 not ready.
+
 ## AUTO/ASK/ESCALATE
 
-- **AUTO:** Flag alignment issues, missing states, obvious inconsistencies
-- **ASK:** Style direction choices, animation priority, screen adaptation tradeoffs
-- **ESCALATE:** Art style fundamentally inconsistent (multiple conflicting styles), UI unusable at target resolution
+- **AUTO:** Flag measurable threshold violations (font size, touch targets, contrast ratios, safe zone violations, animation frame counts below minimum)
+- **ASK:** Style direction choices, animation priority tradeoffs, screen adaptation strategy (pillarbox vs expand vs crop), severity disputes
+- **ESCALATE:** Art style fundamentally inconsistent (multiple conflicting styles with no art direction justification), UI unusable at target resolution, critical animation bugs in main gameplay loop
 
 ## Anti-Sycophancy
 
 Forbidden:
-- ❌ "Beautiful art style"
-- ❌ "Smooth animations"
-- ❌ "Clean UI"
+- "Beautiful art style"
+- "Smooth animations"
+- "Clean UI"
+- "Polished visuals"
+- "Great aesthetic"
+- "Nice color palette"
+- "Looks professional"
 
-Instead: "Button text is 10px at 720p — below readability threshold (14px min). 3 screens use rounded buttons, 2 use square — inconsistent."
+Instead use specific, measurable observations: "Button text is 10px at 720p — below readability threshold (14px min). 3 screens use rounded buttons, 2 use square — inconsistent."
+
+Push-back cadence: After every 3 positive findings, actively look for one issue. If you find none, state: "Checked [area] for [specific problem] — none found."
+
+Calibrated acknowledgment examples:
+- "Walk cycle is 8 frames with correct contact/pass/up/down phases. Foot sliding is under 1px — within tolerance."
+- "Color contrast on main HUD passes WCAG AA (measured 5.2:1). Settings menu contrast is 2.9:1 — below 4.5:1 minimum for body text."
 
 ## Completion Summary
 
 ```
 Visual QA:
   Scope: [full/screen/UI/animation]
-  Issues: ___ high, ___ medium, ___ low
+  Art style: [pixel/2D/3D-stylized/3D-realistic/mixed]
+  Issues: ___ critical, ___ high, ___ medium, ___ low
   Visual Score: _/10
   STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
 ```

--- a/skills/game-visual-qa/SKILL.md.tmpl
+++ b/skills/game-visual-qa/SKILL.md.tmpl
@@ -8,9 +8,24 @@ user_invocable: true
 
 {{PREAMBLE}}
 
+## Load References
+
+```bash
+echo "=== Loading game-visual-qa reference files ==="
+ls references/*.md 2>/dev/null | while read f; do echo "  $f"; done
+```
+
+**Read ALL `references/` files NOW before any user interaction.** They contain visual thresholds, animation standards, platform requirements, scoring model, and gotchas. Zero interruption — load everything upfront.
+
+## Scope Boundaries
+
+- `/game-visual-qa`: Reviews the **visual output** of a built game (what the player sees on screen)
+- `/asset-review`: Reviews **asset files** in the project (formats, sizes, naming, pipeline)
+- `/game-qa` Section 3: Quick visual pass as part of full QA — use `/game-visual-qa` for deep visual-only review
+
 # /game-visual-qa: Visual Quality Assurance
 
-Systematic visual review of game screens, UI, animations, and art consistency.
+Systematic visual review of game screens, UI, animations, and art consistency. Apply `references/gotchas.md` throughout the entire review.
 
 ## Step 0: Visual Context
 
@@ -20,17 +35,35 @@ AskUserQuestion: What are we reviewing?
 - C) UI-only review
 - D) Animation review
 
-Establish: Art style reference (art bible? moodboard? reference game?), target resolution, target platforms.
+Establish:
+1. **Art style reference** — art bible, moodboard, or reference game?
+2. **Art style classification**: A) Pixel art, B) Hand-drawn/2D, C) 3D stylized, D) 3D realistic, E) Mixed media
+   - Style classification affects which thresholds from `references/animation-standards.md` apply
+3. **Target resolution** and **target platforms** (determines thresholds from `references/platform-requirements.md`)
+4. **Build status** — final art, WIP, or placeholder? (See `references/gotchas.md` Scope Traps)
+
+**STOP.** Confirm context before proceeding.
 
 ## Section 1: First Impression (weight: 10%)
+
+**AI confidence: 25% — first impressions are inherently subjective. This section is a prompt for human evaluation, not an AI judgment.**
 
 1-second gut reaction:
 - Professional or amateur?
 - Cohesive or inconsistent?
 - Clear or cluttered?
-- Score: 0-10
+
+Forcing questions:
+- "If you saw this screenshot on a store page with no title, would you wishlist it?"
+- "What genre and quality tier does the art communicate in the first second?"
+
+Score using the per-section scoring from `references/scoring.md`. Section 1 Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 2: Art Style Consistency (weight: 20%)
+
+**AI confidence: 35% — style evaluation requires art direction context. Flag inconsistencies but defer final judgment to the user.**
 
 - Color palette adherence — Do all elements use the same palette?
 - Line weight consistency — Outlines same thickness across all assets?
@@ -39,51 +72,92 @@ Establish: Art style reference (art bible? moodboard? reference game?), target r
 - Environmental scale — Objects correct size relative to characters?
 - Effect style — Particles/VFX match the art style? (realistic effects in pixel art = mismatch)
 
-Score: Start at 10, each inconsistency: high-impact -2, medium -1, low -0.5
+Forcing questions:
+- "Show me the 2 most visually different screens side by side. Are they from the same game?"
+- "If you removed the HUD, could you identify which game this screenshot is from?"
+
+Classify severity per issue using `references/scoring.md` severity definitions. Score: Start at 10, deduct per issue found.
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 3: UI Polish (weight: 20%)
 
-- Alignment — Elements on grid? Consistent margins?
-- Typography — Font hierarchy clear? Readable at target resolution?
+**AI confidence: 65% — most UI checks are measurable against `references/visual-thresholds.md`.**
+
+- Alignment — Elements on grid? Consistent margins? (see `references/visual-thresholds.md` Pixel Alignment)
+- Typography — Font hierarchy clear? Readable at target resolution? (see font size minimums)
 - Color meaning — Consistent (red = damage, green = heal) across ALL screens?
-- Touch/click targets — Minimum 44px on mobile? No overlapping targets?
+- Touch/click targets — Meet platform minimums from `references/visual-thresholds.md`?
 - States — Hover, pressed, disabled, loading states all designed?
 - Transitions — Screens transition smoothly? No jarring cuts?
 
-Score: Same deduction model.
+Forcing questions:
+- "Navigate the 3 most-used menus using only the intended input method. Any hesitation point?"
+- "Screenshot every screen with text. Is the font hierarchy identical across all of them?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 4: Animation Quality (weight: 20%)
 
-- Frame rate — Smooth at target FPS? Any judder?
-- Anticipation — Actions have wind-up? (makes them readable)
-- Follow-through — Actions have recovery? (makes them feel weighty)
+**AI confidence: 60% — frame counts and blend times are measurable; feel and weight are subjective.**
+
+- Frame count — Meets guidelines from `references/animation-standards.md` for the art style?
+- Anticipation — Actions have wind-up >= 2 frames? (makes them readable)
+- Follow-through — Actions have recovery >= 2 frames? (makes them feel weighty)
 - Timing — Fast actions feel fast? Heavy actions feel heavy?
-- Blending — Transitions between animations smooth? No T-pose flashes?
+- Blending — Transition times within targets from `references/animation-standards.md`? No T-pose flashes?
 - Idle — Characters alive when not acting? Breathing, blinking, shifting weight?
 
-Score: Same deduction model.
+Forcing questions:
+- "Play the most common action at 0.25x speed. Is every frame intentional?"
+- "Watch a character stand idle for 30 seconds. Do they feel alive?"
+
+Check against common animation bugs in `references/animation-standards.md`. Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 5: Screen Adaptation (weight: 15%)
 
-- Aspect ratios — 16:9, 18:9, 21:9, 4:3 — nothing cut off?
-- Safe zone — Critical UI elements within safe area?
-- Scaling — Text readable on smallest target screen?
-- Notch/cutout — Content not hidden behind camera notch?
+**AI confidence: 75% — safe zones and aspect ratios are fully measurable against `references/platform-requirements.md`.**
+
+- Aspect ratios — Test at widest and narrowest supported ratio. Nothing cut off?
+- Safe zone — Critical UI within safe area per `references/platform-requirements.md`?
+- Scaling — Text readable on smallest target screen? (check against `references/visual-thresholds.md`)
+- Notch/cutout — Content not hidden behind camera notch? Uses platform safe area APIs?
 - Orientation — If mobile: landscape/portrait handled correctly?
 
-Score: Same deduction model.
+Forcing questions:
+- "Screenshot the main gameplay screen at 4:3 (iPad) and 19.5:9 (iPhone). What breaks?"
+- "Can you read all HUD text on the smallest target device at arm's length?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Section 6: Performance Visual (weight: 15%)
+
+**AI confidence: 70% — most performance visuals are observable, though root causes may not be.**
 
 - Texture quality — No blurry textures at expected view distance?
 - Pop-in — LOD transitions visible? Asset streaming visible?
 - Z-fighting — Overlapping surfaces flickering?
 - Overdraw — Excessive transparency layers? (check with wireframe)
 - Particle budget — Particle effects reasonable? No FPS drop during effects?
+- Frame pacing — Consistent frame delivery? (see FPS targets in `references/animation-standards.md`)
 
-Score: Same deduction model.
+Forcing questions:
+- "Run through the busiest scene in the game. Any visual hitches or pop-in?"
+- "Toggle between lowest and highest quality settings. What changes are visible?"
+
+Classify severity per issue using `references/scoring.md`. Score: ___/10
+
+**STOP.** One issue per AskUserQuestion.
 
 ## Scoring
+
+Calculate weighted final score using formula from `references/scoring.md`:
 
 ```
 Visual QA Score:
@@ -97,27 +171,40 @@ Visual QA Score:
   WEIGHTED TOTAL:         _/10
 ```
 
+Interpret using score ranges from `references/scoring.md`: 90-100 ship-ready, 75-89 shippable with known issues, 60-74 needs work, below 60 not ready.
+
 ## AUTO/ASK/ESCALATE
 
-- **AUTO:** Flag alignment issues, missing states, obvious inconsistencies
-- **ASK:** Style direction choices, animation priority, screen adaptation tradeoffs
-- **ESCALATE:** Art style fundamentally inconsistent (multiple conflicting styles), UI unusable at target resolution
+- **AUTO:** Flag measurable threshold violations (font size, touch targets, contrast ratios, safe zone violations, animation frame counts below minimum)
+- **ASK:** Style direction choices, animation priority tradeoffs, screen adaptation strategy (pillarbox vs expand vs crop), severity disputes
+- **ESCALATE:** Art style fundamentally inconsistent (multiple conflicting styles with no art direction justification), UI unusable at target resolution, critical animation bugs in main gameplay loop
 
 ## Anti-Sycophancy
 
 Forbidden:
-- ❌ "Beautiful art style"
-- ❌ "Smooth animations"
-- ❌ "Clean UI"
+- "Beautiful art style"
+- "Smooth animations"
+- "Clean UI"
+- "Polished visuals"
+- "Great aesthetic"
+- "Nice color palette"
+- "Looks professional"
 
-Instead: "Button text is 10px at 720p — below readability threshold (14px min). 3 screens use rounded buttons, 2 use square — inconsistent."
+Instead use specific, measurable observations: "Button text is 10px at 720p — below readability threshold (14px min). 3 screens use rounded buttons, 2 use square — inconsistent."
+
+Push-back cadence: After every 3 positive findings, actively look for one issue. If you find none, state: "Checked [area] for [specific problem] — none found."
+
+Calibrated acknowledgment examples:
+- "Walk cycle is 8 frames with correct contact/pass/up/down phases. Foot sliding is under 1px — within tolerance."
+- "Color contrast on main HUD passes WCAG AA (measured 5.2:1). Settings menu contrast is 2.9:1 — below 4.5:1 minimum for body text."
 
 ## Completion Summary
 
 ```
 Visual QA:
   Scope: [full/screen/UI/animation]
-  Issues: ___ high, ___ medium, ___ low
+  Art style: [pixel/2D/3D-stylized/3D-realistic/mixed]
+  Issues: ___ critical, ___ high, ___ medium, ___ low
   Visual Score: _/10
   STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
 ```
@@ -136,5 +223,5 @@ Discoverable by: /game-ship, /game-qa
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"game-visual-qa","timestamp":"TIMESTAMP","status":"STATUS","visual_score":SCORE,"issues":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"{{SKILL_NAME}}","timestamp":"TIMESTAMP","status":"STATUS","visual_score":SCORE,"issues":N,"commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/game-visual-qa/references/animation-standards.md
+++ b/skills/game-visual-qa/references/animation-standards.md
@@ -1,0 +1,85 @@
+# Animation Standards
+
+Frame counts, timing benchmarks, and QA checks mapped to animation principles.
+
+## Frame Count Guidelines by Style
+
+### Pixel Art / 2D Sprite
+
+| Animation    | Frame Range | Notes |
+|-------------|------------|-------|
+| Idle         | 4-8f       | Minimum: breathing/blinking cycle |
+| Walk         | 6-8f       | 2f per contact, pass, up, down |
+| Run          | 6-10f      | Faster cadence than walk, not just sped up |
+| Attack       | 4-8f       | Anticipation 1-2f, action 1-2f, recovery 2-4f |
+| Death        | 6-12f      | Can be longer for drama |
+| Jump         | 4-6f       | Takeoff 1-2f, apex 1f, land 2-3f |
+| Hit react    | 3-5f       | Flash + recoil, return to idle |
+
+### 3D / High Fidelity
+
+| Animation    | Frame Range | Notes |
+|-------------|------------|-------|
+| Idle         | 24-90f     | Breathing, weight shifts, micro-movements |
+| Walk         | 16-24f     | Full stride cycle at 30fps |
+| Run          | 12-20f     | Shorter stride, higher cadence |
+| Attack       | 8-20f      | Anticipation 2-4f, action 2-4f, recovery 4-12f |
+| Death        | 24-60f     | Ragdoll or animated, style dependent |
+| Jump         | 8-16f      | Crouch 2-4f, launch 1-2f, hang 2-4f, land 3-6f |
+| Hit react    | 6-12f      | Stagger relative to hit strength |
+
+## 12 Principles Mapped to QA Checks
+
+| Principle | QA Check | Severity if Missing |
+|-----------|----------|-------------------|
+| Anticipation | Action has wind-up >= 2 frames? Player can read what's coming? | High (combat), Medium (non-combat) |
+| Follow-through | Action has recovery >= 2 frames? Doesn't snap to idle? | High (feels robotic without it) |
+| Timing | Heavy objects have slower ease-in? Light objects are snappy? | Medium |
+| Squash & stretch | Present in character movement? (Art style dependent — skip for rigid styles) | Low (style choice) |
+| Arcs | Limbs follow natural arcs, not linear paths? | Medium (3D), Low (pixel art) |
+| Secondary action | Hair, cloth, accessories follow primary motion? | Low-Medium |
+| Ease in/out | Movements accelerate and decelerate? No constant-speed motion? | Medium |
+| Staging | Player's eye drawn to the important action? Clear silhouette? | High |
+| Exaggeration | Actions readable at game camera distance? Not too subtle? | Medium |
+| Solid drawing | 3D models maintain volume during animation? No mesh collapse? | High if visible |
+| Appeal | Characters feel alive and intentional? Not generic or stiff? | Low (subjective) |
+| Straight ahead / pose-to-pose | N/A for QA — this is a production method, not a quality check | — |
+
+## FPS Targets by Platform
+
+| Platform       | Minimum | Target | Premium |
+|---------------|---------|--------|---------|
+| Mobile         | 30fps   | 60fps  | —       |
+| PC             | 60fps   | 60fps  | 120/144fps |
+| Console (current gen) | 30fps | 60fps | 120fps |
+| Console (last gen) | 30fps | 30fps | 60fps |
+| VR             | 72fps   | 90fps  | 120fps  |
+| Nintendo Switch | 30fps  | 30fps  | 60fps   |
+
+Frame pacing matters as much as frame rate. Consistent 30fps feels better than unstable 40-60fps.
+
+## Animation Blend Times
+
+| Transition Type        | Target  | Maximum | Notes |
+|-----------------------|---------|---------|-------|
+| Idle to walk          | <150ms  | 200ms   | Should feel responsive |
+| Walk to run           | <150ms  | 200ms   | Gradual speed ramp OK |
+| Idle to action        | <100ms  | 150ms   | Combat responsiveness critical |
+| Action to idle        | <200ms  | 300ms   | Recovery can be slower |
+| Any to hit react      | <50ms   | 100ms   | Must feel immediate |
+| Any to death          | <100ms  | 150ms   | — |
+| Locomotion direction change | <100ms | 200ms | Affects perceived control lag |
+
+## Common Animation Bugs
+
+| Bug | Description | Severity |
+|-----|-------------|----------|
+| T-pose flash | Default pose visible for 1+ frames during transition | High |
+| Foot sliding | Feet move relative to ground during walk/run (> 2px/cycle) | High |
+| Root motion desync | Character drifts from intended position over time | High |
+| Blend tree dead zone | Input range where no animation plays or blending breaks | Medium |
+| Animation pop | Abrupt transition between states (missing blend) | Medium |
+| Clipping | Body parts passing through other meshes during animation | Medium-Low |
+| IK failure | Feet floating above or sinking into terrain | Medium |
+| Jitter | Rapid oscillation between two animation states | High |
+| Missing animation | Action has no animation, character slides or snaps | Critical |

--- a/skills/game-visual-qa/references/gotchas.md
+++ b/skills/game-visual-qa/references/gotchas.md
@@ -1,0 +1,50 @@
+# Gotchas
+
+False positives, platform quirks, AI misjudgments, and scope traps for visual QA.
+
+## False Positives (Intentional Art Choices)
+
+These look like bugs but may be deliberate. Always ASK before flagging:
+
+- **Deliberate pixel offset**: Hand-drawn or sketchy styles intentionally break grid alignment
+- **Intentional screen shake**: Camera shake, hit feedback, and impact effects are features
+- **Stylized color banding**: Posterization or limited palette can be an art choice (e.g., Return of the Obra Dinn)
+- **Intentional aliasing**: Some pixel art games avoid anti-aliasing to maintain crispness
+- **Frame rate limiting per element**: UI at 60fps but character animations at 12fps is a stylistic choice in some 2D games
+- **Asymmetric UI**: Deliberately off-center or irregular layouts for artistic effect
+- **Visible brush strokes / texture**: Painterly styles have intentional imperfection
+
+Rule: If something looks wrong but is consistent across the game, it's likely intentional. Check art reference docs before flagging.
+
+## Platform-Specific Quirks
+
+| Quirk | Platforms | Impact |
+|-------|----------|--------|
+| Gamma differences | Mac displays brighter than Windows by default | Colors look different cross-platform; test on both |
+| Color space (sRGB vs Display P3) | Mac, iPhone use P3; most PCs use sRGB | Saturated colors may look different or clipped |
+| HDR brightness perception | HDR vs SDR displays | Bloom, glow, and UI brightness can look dramatically different |
+| Font rendering | ClearType (Windows) vs Core Text (Mac) vs FreeType (Linux) | Same font renders with different weight and clarity |
+| Display scaling | Windows 125/150%, macOS 2x, Android density buckets | UI elements may render at unexpected sizes |
+
+## Common AI Misjudgments
+
+When reviewing visual quality, AI frequently gets these wrong:
+
+1. **Mixed-media styles**: 2D characters on 3D backgrounds, or pixel art UI on HD game — this is intentional in many games, not an inconsistency
+2. **Limited-animation styles**: Cutout animation (South Park style), visual novel limited poses, or motion comic presentation intentionally have fewer frames
+3. **Cultural art conventions**: Anime proportions, chibi style, super-deformed characters — proportional "inconsistency" is the style
+4. **Retro aesthetic**: CRT scanlines, color palette limitations, dithering patterns are deliberate throwbacks
+5. **Performance vs quality tradeoffs**: Lower-quality distant objects, simplified shadows on mobile — these are optimization choices, not bugs
+6. **Art in progress**: Prototype or alpha art should be evaluated against its own stated quality target, not against final art standards
+
+## Scope Traps
+
+Avoid wasting review time on these:
+
+- **Placeholder art**: Do not review programmer art or stock assets as if they were final. Ask: "Is this final art?" before scoring.
+- **Non-final rigs**: Animation quality on WIP character rigs will change. Note issues but don't score harshly.
+- **Non-target resolutions**: If the game targets 1080p mobile, don't penalize appearance at 4K on a 32" monitor.
+- **Debug visualizations**: Collision boxes, nav meshes, frame rate counters left visible — flag for removal but don't score as visual bugs.
+- **Unfinished screens**: If a screen is marked as "TODO" or "WIP" in the build, skip it or score separately.
+
+Rule: Establish what is "in scope for review" in Step 0. Everything else gets noted but not scored.

--- a/skills/game-visual-qa/references/platform-requirements.md
+++ b/skills/game-visual-qa/references/platform-requirements.md
@@ -1,0 +1,89 @@
+# Platform Requirements
+
+Safe zones, resolution tiers, aspect ratios, and platform-specific visual requirements.
+
+## Safe Zones
+
+### Television / Console
+
+| Zone | Coverage | Usage |
+|------|----------|-------|
+| Action safe | 90% of screen (5% inset each edge) | All interactive elements must be inside |
+| Title safe | 80% of screen (10% inset each edge) | All text and critical info must be inside |
+
+Modern TVs have less overscan than CRTs, but compliance is still required for console certification.
+
+### Mobile Devices
+
+| Area | Spec | Handling |
+|------|------|----------|
+| iOS status bar | 44pt top (iPhone with Dynamic Island), 20pt (older) | Do not place interactive elements here |
+| iOS home indicator | 34pt bottom | Avoid placing critical UI at very bottom |
+| Android status bar | 24-28dp top (varies by device) | Use system insets API |
+| Android navigation bar | 48dp bottom (gesture or button) | Use system insets API |
+| Notch/punch-hole | Device-specific | Use safe area insets; test with simulator |
+| Foldable crease | Center screen on fold devices | Avoid critical UI at fold line |
+
+Rule: Use platform safe area APIs. Hardcoded pixel offsets will break on new devices.
+
+### PC
+
+No mandatory safe zones, but:
+- Windowed mode: UI must not rely on being at screen edge
+- Ultrawide: HUD should anchor to 16:9 center, not stretch to edges
+- Multi-monitor: Ensure UI renders on primary monitor only
+
+## Resolution Tiers
+
+| Tier | Resolution | Use Case |
+|------|-----------|----------|
+| Low | 720p (1280x720) | Mobile minimum, Switch handheld |
+| Standard | 1080p (1920x1080) | Mobile target, PC minimum, console base |
+| High | 1440p (2560x1440) | PC target, PS5/Xbox Series quality mode |
+| Ultra | 4K (3840x2160) | PC high-end, console performance target |
+
+Test at minimum and target. If assets look acceptable at 720p and sharp at 1080p, the resolution tiers pass.
+
+## Aspect Ratios
+
+| Ratio | Width:Height | Common Devices |
+|-------|-------------|---------------|
+| 4:3   | 1.33:1      | iPad (all models) |
+| 16:10 | 1.60:1      | Steam Deck (1280x800), some laptops |
+| 16:9  | 1.78:1      | **Baseline** — most monitors, TVs, consoles |
+| 18:9  | 2.00:1      | Modern Android phones |
+| 19.5:9 | 2.17:1     | Modern iPhones |
+| 21:9  | 2.33:1      | Ultrawide monitors |
+| 32:9  | 3.56:1      | Super ultrawide monitors |
+
+Strategy options:
+1. **Pillarbox/letterbox**: Black bars, safe but wastes screen
+2. **Expand viewport**: Show more of the game world, may reveal unintended areas
+3. **Crop**: Fill screen but lose content at edges — dangerous for UI
+4. **Hybrid**: Expand to a limit, then letterbox beyond that
+
+Critical check: What happens at the widest AND narrowest supported ratio? Take screenshots of both.
+
+## HDR Requirements
+
+| Requirement | Spec |
+|-------------|------|
+| Peak brightness | Platform-specific (400-1000 nits typical) |
+| Tone mapping | SDR content must render correctly in HDR mode |
+| SDR fallback | Game must look correct with HDR disabled |
+| Paper white | UI reference white should be ~200 nits, not peak |
+| Color space | Rec. 2020 container, P3 gamut typical |
+
+Common HDR bugs: UI looks washed out, bloom is overblown, dark areas crushed to pure black.
+
+## Platform-Specific Gotchas
+
+| Platform | Gotcha | Impact |
+|----------|--------|--------|
+| Steam Deck | 1280x800 (16:10), 7" screen | Font sizes designed for 1080p may be unreadable |
+| Nintendo Switch | 720p handheld, 1080p docked | Must test BOTH modes; assets that look fine docked may be illegible handheld |
+| iPad | 4:3 aspect ratio | Games designed for 16:9 will have significant vertical bars or layout issues |
+| Older iPhones | Varied notch sizes | Test multiple notch generations, not just latest |
+| Samsung foldables | Inner/outer screen ratio change | UI must adapt to dramatic aspect ratio shift |
+| PS VR2 / Quest | Per-eye rendering, barrel distortion | UI placement must account for lens distortion |
+| macOS Retina | 2x display scaling | Pixel art must render at integer multiples or will blur |

--- a/skills/game-visual-qa/references/scoring.md
+++ b/skills/game-visual-qa/references/scoring.md
@@ -1,0 +1,53 @@
+# Scoring Model
+
+Deduction-based visual QA scoring. Start at 100, deduct per issue found.
+
+## Severity Definitions
+
+| Severity | Deduction | Definition | Examples |
+|----------|-----------|------------|---------|
+| Critical | -25 | Renders game unplayable or poses health risk | Black screen, seizure-inducing flashing, rendering corruption that blocks gameplay |
+| High | -15 | Always visible during normal play | Wrong animation state in main loop, UI overlap hiding gameplay info, persistent Z-fighting in main area, T-pose flash |
+| Medium | -8 | Sometimes visible during normal play | Occasional texture pop-in, animation blend glitch on rare transition, minor UI misalignment on secondary screen |
+| Low | -3 | Only visible when actively looking for it | 1px misalignment, sub-pixel font rendering artifact, texture seam at extreme camera angle |
+
+## Severity Dispute Decision Tree
+
+When severity classification is unclear, walk through these questions in order:
+
+1. **Would a player screenshot this and post it as a bug?** -> Critical or High
+2. **Would a player notice this during focused gameplay without looking for it?** -> High or Medium
+3. **Would a player notice this only during a pause, menu, or slow moment?** -> Medium
+4. **Would a player only see this if deliberately zooming in or frame-stepping?** -> Low
+
+Tiebreaker: How frequently does the player encounter this screen/state?
+- Main gameplay loop (every session) -> bump up one severity level
+- Occasional screen (settings, inventory) -> keep current level
+- Rare screen (credits, one-time tutorial) -> bump down one severity level
+
+## Per-Section Scoring
+
+Each section starts at 10 points. Convert deductions to the 10-point scale:
+- Critical issue: -2.5 per occurrence
+- High issue: -1.5 per occurrence
+- Medium issue: -0.8 per occurrence
+- Low issue: -0.3 per occurrence
+
+Minimum score per section: 0. No negative scores.
+
+## Score Interpretation
+
+| Score Range | Status | Meaning |
+|------------|--------|---------|
+| 90-100 | Ship-ready | Minor issues only, no action required |
+| 75-89 | Shippable with known issues | High-priority issues documented, team accepts risk |
+| 60-74 | Needs work | Multiple high-severity issues, should not ship without fixes |
+| Below 60 | Not ready | Critical or numerous high-severity issues, release blocked |
+
+## Weighted Final Score
+
+```
+Final = (S1 * 0.10) + (S2 * 0.20) + (S3 * 0.20) + (S4 * 0.20) + (S5 * 0.15) + (S6 * 0.15)
+```
+
+Where S1-S6 are the per-section scores (0-10 scale).

--- a/skills/game-visual-qa/references/visual-thresholds.md
+++ b/skills/game-visual-qa/references/visual-thresholds.md
@@ -1,0 +1,64 @@
+# Visual Thresholds
+
+Quantifiable visual quality minimums. Use these as pass/fail criteria — not suggestions.
+
+## Font Size Minimums (by resolution)
+
+| Resolution | Body Text Min | Heading Min | HUD/Label Min | Tooltip Min |
+|------------|--------------|-------------|---------------|-------------|
+| 720p       | 14px         | 18px        | 12px          | 11px        |
+| 1080p      | 16px         | 20px        | 14px          | 12px        |
+| 1440p      | 18px         | 24px        | 16px          | 14px        |
+| 4K         | 24px         | 32px        | 20px          | 18px        |
+
+Rule: If text is unreadable at arm's length on target device, it fails regardless of pixel count.
+
+## Touch/Click Target Minimums
+
+| Platform      | Minimum Size | Minimum Spacing |
+|---------------|-------------|-----------------|
+| iOS           | 44pt x 44pt | 8pt between targets |
+| Android       | 48dp x 48dp | 8dp between targets |
+| PC (mouse)    | 24px x 24px | 4px between targets |
+| Console (D-pad) | N/A (focus-based) | Clear focus indicator required |
+
+Common failure: Button visual is 32px but tap area is also 32px. Visual can be smaller than tap area — tap area cannot be smaller than minimum.
+
+## Color Contrast Ratios (WCAG AA)
+
+| Element Type        | Minimum Ratio | Example Pass | Example Fail |
+|--------------------|---------------|-------------|-------------|
+| Body text          | 4.5:1         | #333 on #FFF (12.6:1) | #999 on #FFF (2.8:1) |
+| Large text (>=18px bold, >=24px) | 3:1 | #666 on #FFF (5.7:1) | #AAA on #FFF (2.3:1) |
+| UI components      | 3:1           | Button border visible | Ghost button on light bg |
+| Non-essential decorative | No minimum | — | — |
+
+Game exception: In-world text (signs, graffiti, environmental storytelling) follows art direction, not WCAG. HUD/UI text always follows WCAG.
+
+## Pixel Alignment
+
+| Context          | Tolerance |
+|------------------|-----------|
+| UI elements      | 0px — must snap to pixel grid |
+| Pixel art sprites | 0px — sub-pixel = visible blur |
+| 3D UI overlays   | 1px — rendering can shift slightly |
+| Game world objects | Art-direction dependent |
+
+Test: Screenshot at 1x zoom. If any UI element has blurry edges from sub-pixel positioning, it fails.
+
+## Icon Legibility
+
+| Context        | Minimum Size | With Label | Without Label |
+|----------------|-------------|-----------|---------------|
+| Toolbar/menu   | 24px        | OK at 20px | Must be 24px+ |
+| HUD            | 32px        | OK at 24px | Must be 32px+ |
+| Mobile primary | 44px        | OK at 32px | Must be 44px+ |
+
+Rule: If an icon requires a tooltip to identify, it needs either a label or a redesign.
+
+## Text Readability
+
+- Maximum line length: 60-80 characters (including spaces)
+- Minimum line height: 1.4x font size (body), 1.2x (headings)
+- Paragraph spacing: >= 0.5x font size between paragraphs
+- Text should never touch container edges — minimum padding 8px


### PR DESCRIPTION
## Summary

- Add 5 reference files (`references/`) with domain knowledge: visual thresholds (font sizes, touch targets, contrast ratios), animation standards (frame counts, blend times, 12 principles mapped to QA checks), platform requirements (safe zones, aspect ratios), scoring model (deduction-based: Critical -25 to Low -3), and gotchas (false positives, AI misjudgments)
- Expand template from 140L skeleton to 227L with Load References block, forcing questions (2 per section), severity classification, AI confidence disclaimers on subjective sections, expanded anti-sycophancy (7 forbidden phrases + push-back cadence), and scope boundaries with `/asset-review` and `/game-qa`
- Moves `/game-visual-qa` from Skeleton (35%) to A-type (55-65%) quality tier

Closes #6.

## Test plan

- [x] `bun run build` succeeds (all 27 SKILL.md files generated)
- [x] `bun run gen:skill-docs:check` shows no drift
- [x] `bun test` shows 10 pass, 1 pre-existing fail (frontmatter check unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)