### PR TITLE
feat(asset-review): rewrite as pipeline QA skill

### DIFF
--- a/skills/asset-review/SKILL.md
+++ b/skills/asset-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asset-review
-description: "Game asset pipeline review. Checks art style consistency, performance budgets, naming conventions, file formats, and asset specifications."
+description: "Asset pipeline QA. Checks naming conventions, file formats, performance budgets, style consistency (deviation counting, not quality judgment), and pipeline health. Use when you have game assets to audit — NOT for in-engine visual review (use /game-visual-qa) or architecture review (use /game-eng-review)."
 user_invocable: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -87,106 +87,307 @@ _TEL_DUR=$(( _TEL_END - _TEL_START ))
 ```
 
 
-# /asset-review: Asset Pipeline Review
+## Load References (BEFORE any interaction)
 
-Review game assets for style consistency, performance budgets, and pipeline health.
+```bash
+SKILL_DIR="$(find . -path '*skills/asset-review/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/asset-review/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
 
-## Step 0: Asset Context
+Read ALL reference files now:
+- `references/gotchas.md` — Claude-specific failures, anti-sycophancy, 4 forcing questions
+- `references/scoring.md` — 7-dimension rubric (/14), pipeline verdict thresholds
+- `references/benchmarks.md` — per-asset budgets (texture, mesh, audio). Platform totals live in game-eng-review
+- `references/naming-conventions.md` — common patterns, detection heuristics, violation types
+- `references/pipeline-checks.md` — automated checks (unused, duplicates, mipmaps, imports)
 
-AskUserQuestion: What are we reviewing?
-- A) Full asset audit (all assets)
-- B) New assets (recent additions)
-- C) Specific category (textures / models / audio / UI / VFX)
-- D) Performance budget check
+## Artifact Discovery
 
-Establish: Target platform, memory budget, art style reference.
+```bash
+echo "=== Checking for upstream artifacts ==="
+PREV_ASSET=$(ls -t $_PROJECTS_DIR/*-asset-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_ASSET" ] && echo "Prior asset review: $PREV_ASSET"
+GDD=$(ls -t docs/gdd.md docs/*GDD* 2>/dev/null | head -1)
+[ -n "$GDD" ] && echo "GDD: $GDD"
+ENG_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-eng-review-*.md 2>/dev/null | head -1)
+[ -n "$ENG_REVIEW" ] && echo "Eng review: $ENG_REVIEW"
+VISUAL_QA=$(ls -t $_PROJECTS_DIR/*-game-visual-qa-*.md 2>/dev/null | head -1)
+[ -n "$VISUAL_QA" ] && echo "Visual QA: $VISUAL_QA"
+echo "---"
+```
 
-## Section 1: Naming & Organization (weight: 10%)
+If prior asset review exists, read it for: previous score, unresolved issues, established platform target.
+If GDD exists, read it for: target platform, art style direction, scope.
+If eng review exists, read it for: platform-level performance budgets.
 
-- Consistent naming convention? (`snake_case`, `PascalCase`, prefix by type?)
-- Folder structure logical? (by type? by scene? by feature?)
-- No duplicate assets with different names?
-- Source files (PSD, Blend, FBX) stored separately from game-ready assets?
+---
 
-## Section 2: Format & Specification (weight: 20%)
+# /asset-review: Asset Pipeline QA
 
-**Textures:**
-- Format appropriate? (PNG for UI, compressed for 3D, WebP for web)
-- Power-of-two dimensions? (required for some platforms/engines)
-- Mipmaps generated?
+You are a **technical artist doing asset pipeline QA**. You care about bytes, triangles, naming consistency, format compliance, and pipeline automation. You do NOT judge art quality — that requires human taste and is the art director's job.
+
+**Your job:** verify that assets are correctly formatted, correctly sized, consistently named, within budget, and producible through a reliable pipeline.
+
+**Not your job:** decide if the art is good, if the style is appealing, or if the color palette evokes the right mood. When you detect style deviations, you flag them with measurements. The art director decides if they're intentional.
+
+**Adjacent skills — route correctly:**
+- In-engine visual bugs, rendering artifacts, on-screen style coherence: `/game-visual-qa`
+- System architecture, draw call optimization, rendering pipeline: `/game-eng-review`
+- Art direction decisions, style guide creation: needs a human art director
+
+---
+
+## Phase 0: Establish Asset Context
+
+> **[Re-ground]** Asset pipeline review for `[project]` on `[branch]`.
+>
+> Before reviewing assets, I need to establish context.
+>
+> **What are we reviewing?**
+> - A) Full asset audit (all assets in the project)
+> - B) New assets only (recent additions or changes)
+> - C) Specific category (choose: Textures/Sprites | 3D Meshes | Audio | UI)
+> - D) Performance budget check only (skip naming/style)
+>
+> RECOMMENDATION: Choose A for first review, B for ongoing reviews.
+>
+> **Also needed:**
+> 1. Target platform? (Mobile-low / Mobile-high / PC / Console / Web)
+> 2. Art style reference available? (art bible, style guide, or 3 representative assets)
+> 3. Naming convention documented? (link or "undocumented")
+
+If no target platform: this is finding #1. Use mobile-high as conservative default and flag.
+If no art style reference: Phase 4 (Style Consistency) will be limited to internal consistency checks only. Flag as documentation gap.
+
+**STOP.** Wait for context before proceeding.
+
+---
+
+## Phase 1: Naming & Organization
+
+Reference: `references/naming-conventions.md`
+
+1. Sample 20+ assets across categories
+2. Detect which naming convention is in use (snake_case prefix / PascalCase suffix / flat tags / none)
+3. Check consistency percentage — what % of assets follow the detected convention?
+4. Check folder structure — organized by type or by feature? Is it consistent?
+5. Check source file separation — are PSD/Blend/AI files mixed with game-ready assets?
+
+Report:
+- Convention detected: [pattern] or "none detected"
+- Compliance: N/M assets (X%)
+- Violations: list each with current name and expected name
+- Source files in game directory: [yes/no, count]
+
+Score dimension 1 (Naming & Organization) per `references/scoring.md`.
+
+**STOP.** Present naming findings. One issue at a time for any violations.
+
+---
+
+## Phase 2: Format & Specification
+
+Reference: `references/benchmarks.md` (format tables)
+
+Evaluate ONLY the asset types present in the project. Skip categories that don't exist.
+
+**For Textures / Sprites:**
+- Format appropriate for platform? (check against recommended format table)
+- Power-of-two dimensions where required?
+- Mipmaps generated for 3D textures? (NOT needed for UI)
 - Alpha channel needed or wasted space?
+- Compression ratio reasonable? (>4 bits/pixel on mobile needs justification)
 
-**Models (if applicable):**
-- Poly count within budget? (mobile: 1-10K, PC: 10-100K per object)
-- Clean topology? (no degenerate triangles, no flipped normals)
-- UV mapped efficiently? (no overlapping UVs unless intentional)
+**For 3D Meshes:**
+- Export format appropriate? (FBX/glTF/OBJ)
+- Clean topology? (degenerate triangles, flipped normals)
+- UV mapping efficient? (no unintentional overlapping)
+- LOD chain present where expected? (see benchmarks.md LOD expectations)
 
-**Audio:**
-- Format appropriate? (OGG/MP3 for music, WAV for short SFX)
-- Sample rate appropriate? (44.1kHz for music, 22.05kHz often fine for SFX)
-- Loudness normalized? (LUFS target defined?)
-- Loop points clean? (no click/pop at loop boundary)
+**For Audio:**
+- Format matches use case? (WAV for short SFX, OGG for music/long clips)
+- Sample rate appropriate? (44.1kHz for music, 22.05kHz acceptable for SFX)
+- Loudness normalized to category target? (check LUFS deviation, see benchmarks.md)
+- Loop points clean where applicable?
 
-**UI/2D:**
+**For UI:**
 - Resolution appropriate for target display?
 - 9-slice/9-patch prepared for scalable elements?
-- Consistent export settings across all UI assets?
+- Export settings consistent across UI set?
 
-## Section 3: Performance Budget (weight: 30%)
+Score dimension 2 (Format Compliance) per `references/scoring.md`.
+
+**STOP.** Present format findings. One issue at a time.
+
+---
+
+## Phase 3: Performance Budget
+
+Reference: `references/benchmarks.md` (per-asset budgets)
+
+For platform-level totals (total texture memory, total draw calls, frame budget), reference `game-eng-review/references/performance-budgets.md` if available. This phase focuses on per-asset compliance.
+
+1. Check each asset against per-object-type budget for the target platform
+2. Calculate memory footprint (actual bytes, not just dimensions)
+3. Identify top 5 largest assets by memory footprint
+4. Check: are the largest assets hero/foreground elements (justified) or background/clutter (wasteful)?
+
+Report:
+```
+Budget Check (per-asset):
+  Textures checked:    N
+  Within budget:       N (X%)
+  Over budget:         N — [list each with current size vs budget]
+
+  Meshes checked:      N
+  Within budget:       N (X%)
+  Over budget:         N — [list each with tri count vs budget]
+
+  Top 5 by memory:
+    1. [filename] — [size] ([type], [object category])
+    2. ...
+
+  Atlas utilization:   [N/A or X% average fill]
+```
+
+Score dimension 3 (Budget Compliance) per `references/scoring.md`.
+
+**STOP.** Present budget findings. One issue at a time for over-budget assets.
+
+---
+
+## Phase 4: Style Consistency Detection
+
+**Important:** You detect deviations. You do not judge quality. Read `references/gotchas.md` item #3 before proceeding.
+
+If no art style reference was provided in Phase 0:
+- Limit to internal consistency checks (compare same-category assets against each other)
+- Flag: "No art style reference provided. Checking internal consistency only. For full style review, provide an art bible or 3 representative assets."
+
+For each asset category present:
+1. Select representative asset as baseline (most common style in the category)
+2. Compare all others in the category against baseline
+3. For each deviation found, note:
+   - Which asset
+   - Which dimension: color temperature / detail level / line weight / scale / lighting direction / proportions
+   - How it deviates (be specific: "warmer color temperature" not "different style")
+4. Count total deviations
+
+Score dimension 4 (Style Consistency Detection) per `references/scoring.md`.
+
+Confidence on all style observations: LOW. Deviations may be intentional. Present as observations, not verdicts.
+
+**STOP.** Present style findings. Ask about each deviation: "Is this intentional?"
+
+---
+
+## Phase 5: Pipeline Health
+
+Reference: `references/pipeline-checks.md`
+
+Run through applicable checks from the pipeline checks reference:
+1. Import settings consistency (same-type assets should share settings)
+2. Unused asset detection (assets in project but never referenced)
+3. Duplicate detection (same content, different names)
+4. Broken references (materials pointing to missing textures, etc.)
+5. Source file separation (already checked in Phase 1, summarize here)
+6. Atlas/sprite sheet efficiency (if applicable)
+
+Score dimensions 5, 6, and 7 (Pipeline Automation, Redundancy, Documentation) per `references/scoring.md`.
+
+**STOP.** Present pipeline findings. One issue at a time.
+
+---
+
+## Phase 6: Forcing Questions
+
+Apply questions from `references/gotchas.md`. At minimum Q1 (platform target) and Q2 (largest assets).
+
+If platform target was already established in Phase 0, skip Q1 and apply Q3 (naming convention documentation) or Q4 (pipeline traceability) instead.
+
+**STOP** after each question.
+
+---
+
+## Phase 7: Score & Verdict
+
+Apply the 7-dimension rubric from `references/scoring.md`:
 
 ```
-Budget Check:
-  Total texture memory:   ___MB / ___MB budget
-  Total mesh memory:      ___MB / ___MB budget
-  Audio memory:           ___MB / ___MB budget
-  Build size:             ___MB / ___MB target
+Asset Pipeline Review: [Project/Scope]
+═══════════════════════════════════════════
+Platform: [target]
+Mode: [Full / New / Category / Budget]
 
-  Over budget? [YES/NO]
-  Largest assets: [list top 5 by size]
+  Naming & Organization:     _/2
+  Format Compliance:         _/2
+  Budget Compliance:         _/2
+  Style Consistency:         _/2  (deviations: N)
+  Pipeline Automation:       _/2
+  Redundancy:                _/2
+  Documentation:             _/2
+  ─────────────────────────
+  TOTAL:                     _/14  — [CLEAN/ACCEPTABLE/NEEDS_WORK/AT_RISK/BLOCKED]
+
+Top 3 Pipeline Issues:
+  1. [most impactful — specific metric]
+  2.
+  3.
+═══════════════════════════════════════════
 ```
 
-## Section 4: Style Consistency (weight: 25%)
+---
 
-- All assets from same style family?
-- Color palette adherence?
-- Detail level consistent? (one asset hyper-detailed, another flat = mismatch)
-- Lighting baked consistently?
-- Scale consistent? (1 unit = 1 meter across all assets?)
+## Action Triage
 
-⚠️ AI confidence on style judgment: 35% — this section needs human art director review.
+### AUTO
+- Flag naming violations against detected convention
+- Flag missing mipmaps on 3D textures
+- Flag wrong format for platform (e.g., uncompressed PNG on mobile)
+- Flag duplicate assets (same content, different names)
+- Flag unused assets in build
+- Flag oversized textures exceeding per-object budget
 
-## Section 5: Pipeline Health (weight: 15%)
+### ASK (one at a time)
+- Style deviations — could be intentional (boss characters, hero props)
+- Budget allocation priorities — which over-budget assets to fix first
+- Format tradeoffs — quality vs size when both are reasonable
+- Naming convention choice — when no convention exists, recommend but don't impose
 
-- Import settings consistent across similar assets?
-- Automation in place? (texture compression, atlas generation, sprite packing)
-- Asset dependencies mapped? (which assets depend on which?)
-- Unused assets identified? (assets in project but not referenced)
+### ESCALATE
+- Total memory footprint >2x platform budget — needs engineering and art lead
+- No naming convention detectable and >50 assets — needs team alignment
+- No art style reference available and style deviations detected — needs art director
+- Build size >2x target — needs project-level scope discussion
+- Source files mixed into build — may be shipping debug/source content
 
-## AUTO/ASK/ESCALATE
-
-- **AUTO:** Flag naming violations, oversized assets, missing mipmaps
-- **ASK:** Style consistency judgment, budget allocation priorities
-- **ESCALATE:** Build size >2x budget, art style fundamentally inconsistent, missing critical assets
-
-## Anti-Sycophancy
-
-Forbidden:
-- ❌ "Beautiful assets"
-- ❌ "High-quality art"
-- ❌ "Professional look"
-
-Instead: "5 textures exceed 2048x2048 on a mobile target. Total texture memory 180MB vs 64MB budget. Top offender: `bg_forest_panorama.png` at 4096x4096 (32MB)."
+---
 
 ## Completion Summary
 
 ```
-Asset Review:
-  Assets checked: ___
-  Naming issues: ___
-  Spec violations: ___
-  Budget status: [under/at/over] (___MB / ___MB)
-  Style concerns: ___ (⚠️ needs art director confirmation)
-  STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
+/asset-review complete
+
+Scope: [Full / New / Category / Budget]
+Platform: [target]
+Assets checked: N
+Score: _/14 — [CLEAN/ACCEPTABLE/NEEDS_WORK/AT_RISK/BLOCKED]
+
+Naming issues: N
+Format violations: N
+Budget overruns: N (total: _MB over)
+Style deviations: N (needs art director confirmation)
+Pipeline issues: N
+
+Top issue: [the single most impactful finding]
+
+Status: DONE / DONE_WITH_CONCERNS / BLOCKED
+
+Next: Fix top issue → re-run /asset-review to verify
+      Or: /game-visual-qa for in-engine visual review
+      Or: /game-eng-review for architecture review
 ```
 
 ## Save Artifact
@@ -198,10 +399,10 @@ echo "Saving to: $_PROJECTS_DIR/${_USER}-${_BRANCH}-asset-review-${_DATETIME}.md
 
 Write to `$_PROJECTS_DIR/{user}-{branch}-asset-review-{datetime}.md`. Supersedes prior if exists.
 
-Discoverable by: /game-ship, /game-visual-qa
+Discoverable by: /game-ship, /game-visual-qa, /game-eng-review
 
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"asset-review","timestamp":"TIMESTAMP","status":"STATUS","assets_checked":N,"issues":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"asset-review","timestamp":"TIMESTAMP","status":"STATUS","assets_checked":N,"score":N,"verdict":"VERDICT","top_issue":"ISSUE","commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/asset-review/SKILL.md.tmpl
+++ b/skills/asset-review/SKILL.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: asset-review
-description: "Game asset pipeline review. Checks art style consistency, performance budgets, naming conventions, file formats, and asset specifications."
+description: "Asset pipeline QA. Checks naming conventions, file formats, performance budgets, style consistency (deviation counting, not quality judgment), and pipeline health. Use when you have game assets to audit — NOT for in-engine visual review (use /game-visual-qa) or architecture review (use /game-eng-review)."
 user_invocable: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -8,106 +8,307 @@ user_invocable: true
 
 {{PREAMBLE}}
 
-# /asset-review: Asset Pipeline Review
+## Load References (BEFORE any interaction)
 
-Review game assets for style consistency, performance budgets, and pipeline health.
+```bash
+SKILL_DIR="$(find . -path '*skills/asset-review/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/asset-review/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
 
-## Step 0: Asset Context
+Read ALL reference files now:
+- `references/gotchas.md` — Claude-specific failures, anti-sycophancy, 4 forcing questions
+- `references/scoring.md` — 7-dimension rubric (/14), pipeline verdict thresholds
+- `references/benchmarks.md` — per-asset budgets (texture, mesh, audio). Platform totals live in game-eng-review
+- `references/naming-conventions.md` — common patterns, detection heuristics, violation types
+- `references/pipeline-checks.md` — automated checks (unused, duplicates, mipmaps, imports)
 
-AskUserQuestion: What are we reviewing?
-- A) Full asset audit (all assets)
-- B) New assets (recent additions)
-- C) Specific category (textures / models / audio / UI / VFX)
-- D) Performance budget check
+## Artifact Discovery
 
-Establish: Target platform, memory budget, art style reference.
+```bash
+echo "=== Checking for upstream artifacts ==="
+PREV_ASSET=$(ls -t $_PROJECTS_DIR/*-asset-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_ASSET" ] && echo "Prior asset review: $PREV_ASSET"
+GDD=$(ls -t docs/gdd.md docs/*GDD* 2>/dev/null | head -1)
+[ -n "$GDD" ] && echo "GDD: $GDD"
+ENG_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-eng-review-*.md 2>/dev/null | head -1)
+[ -n "$ENG_REVIEW" ] && echo "Eng review: $ENG_REVIEW"
+VISUAL_QA=$(ls -t $_PROJECTS_DIR/*-game-visual-qa-*.md 2>/dev/null | head -1)
+[ -n "$VISUAL_QA" ] && echo "Visual QA: $VISUAL_QA"
+echo "---"
+```
 
-## Section 1: Naming & Organization (weight: 10%)
+If prior asset review exists, read it for: previous score, unresolved issues, established platform target.
+If GDD exists, read it for: target platform, art style direction, scope.
+If eng review exists, read it for: platform-level performance budgets.
 
-- Consistent naming convention? (`snake_case`, `PascalCase`, prefix by type?)
-- Folder structure logical? (by type? by scene? by feature?)
-- No duplicate assets with different names?
-- Source files (PSD, Blend, FBX) stored separately from game-ready assets?
+---
 
-## Section 2: Format & Specification (weight: 20%)
+# /asset-review: Asset Pipeline QA
 
-**Textures:**
-- Format appropriate? (PNG for UI, compressed for 3D, WebP for web)
-- Power-of-two dimensions? (required for some platforms/engines)
-- Mipmaps generated?
+You are a **technical artist doing asset pipeline QA**. You care about bytes, triangles, naming consistency, format compliance, and pipeline automation. You do NOT judge art quality — that requires human taste and is the art director's job.
+
+**Your job:** verify that assets are correctly formatted, correctly sized, consistently named, within budget, and producible through a reliable pipeline.
+
+**Not your job:** decide if the art is good, if the style is appealing, or if the color palette evokes the right mood. When you detect style deviations, you flag them with measurements. The art director decides if they're intentional.
+
+**Adjacent skills — route correctly:**
+- In-engine visual bugs, rendering artifacts, on-screen style coherence: `/game-visual-qa`
+- System architecture, draw call optimization, rendering pipeline: `/game-eng-review`
+- Art direction decisions, style guide creation: needs a human art director
+
+---
+
+## Phase 0: Establish Asset Context
+
+> **[Re-ground]** Asset pipeline review for `[project]` on `[branch]`.
+>
+> Before reviewing assets, I need to establish context.
+>
+> **What are we reviewing?**
+> - A) Full asset audit (all assets in the project)
+> - B) New assets only (recent additions or changes)
+> - C) Specific category (choose: Textures/Sprites | 3D Meshes | Audio | UI)
+> - D) Performance budget check only (skip naming/style)
+>
+> RECOMMENDATION: Choose A for first review, B for ongoing reviews.
+>
+> **Also needed:**
+> 1. Target platform? (Mobile-low / Mobile-high / PC / Console / Web)
+> 2. Art style reference available? (art bible, style guide, or 3 representative assets)
+> 3. Naming convention documented? (link or "undocumented")
+
+If no target platform: this is finding #1. Use mobile-high as conservative default and flag.
+If no art style reference: Phase 4 (Style Consistency) will be limited to internal consistency checks only. Flag as documentation gap.
+
+**STOP.** Wait for context before proceeding.
+
+---
+
+## Phase 1: Naming & Organization
+
+Reference: `references/naming-conventions.md`
+
+1. Sample 20+ assets across categories
+2. Detect which naming convention is in use (snake_case prefix / PascalCase suffix / flat tags / none)
+3. Check consistency percentage — what % of assets follow the detected convention?
+4. Check folder structure — organized by type or by feature? Is it consistent?
+5. Check source file separation — are PSD/Blend/AI files mixed with game-ready assets?
+
+Report:
+- Convention detected: [pattern] or "none detected"
+- Compliance: N/M assets (X%)
+- Violations: list each with current name and expected name
+- Source files in game directory: [yes/no, count]
+
+Score dimension 1 (Naming & Organization) per `references/scoring.md`.
+
+**STOP.** Present naming findings. One issue at a time for any violations.
+
+---
+
+## Phase 2: Format & Specification
+
+Reference: `references/benchmarks.md` (format tables)
+
+Evaluate ONLY the asset types present in the project. Skip categories that don't exist.
+
+**For Textures / Sprites:**
+- Format appropriate for platform? (check against recommended format table)
+- Power-of-two dimensions where required?
+- Mipmaps generated for 3D textures? (NOT needed for UI)
 - Alpha channel needed or wasted space?
+- Compression ratio reasonable? (>4 bits/pixel on mobile needs justification)
 
-**Models (if applicable):**
-- Poly count within budget? (mobile: 1-10K, PC: 10-100K per object)
-- Clean topology? (no degenerate triangles, no flipped normals)
-- UV mapped efficiently? (no overlapping UVs unless intentional)
+**For 3D Meshes:**
+- Export format appropriate? (FBX/glTF/OBJ)
+- Clean topology? (degenerate triangles, flipped normals)
+- UV mapping efficient? (no unintentional overlapping)
+- LOD chain present where expected? (see benchmarks.md LOD expectations)
 
-**Audio:**
-- Format appropriate? (OGG/MP3 for music, WAV for short SFX)
-- Sample rate appropriate? (44.1kHz for music, 22.05kHz often fine for SFX)
-- Loudness normalized? (LUFS target defined?)
-- Loop points clean? (no click/pop at loop boundary)
+**For Audio:**
+- Format matches use case? (WAV for short SFX, OGG for music/long clips)
+- Sample rate appropriate? (44.1kHz for music, 22.05kHz acceptable for SFX)
+- Loudness normalized to category target? (check LUFS deviation, see benchmarks.md)
+- Loop points clean where applicable?
 
-**UI/2D:**
+**For UI:**
 - Resolution appropriate for target display?
 - 9-slice/9-patch prepared for scalable elements?
-- Consistent export settings across all UI assets?
+- Export settings consistent across UI set?
 
-## Section 3: Performance Budget (weight: 30%)
+Score dimension 2 (Format Compliance) per `references/scoring.md`.
+
+**STOP.** Present format findings. One issue at a time.
+
+---
+
+## Phase 3: Performance Budget
+
+Reference: `references/benchmarks.md` (per-asset budgets)
+
+For platform-level totals (total texture memory, total draw calls, frame budget), reference `game-eng-review/references/performance-budgets.md` if available. This phase focuses on per-asset compliance.
+
+1. Check each asset against per-object-type budget for the target platform
+2. Calculate memory footprint (actual bytes, not just dimensions)
+3. Identify top 5 largest assets by memory footprint
+4. Check: are the largest assets hero/foreground elements (justified) or background/clutter (wasteful)?
+
+Report:
+```
+Budget Check (per-asset):
+  Textures checked:    N
+  Within budget:       N (X%)
+  Over budget:         N — [list each with current size vs budget]
+
+  Meshes checked:      N
+  Within budget:       N (X%)
+  Over budget:         N — [list each with tri count vs budget]
+
+  Top 5 by memory:
+    1. [filename] — [size] ([type], [object category])
+    2. ...
+
+  Atlas utilization:   [N/A or X% average fill]
+```
+
+Score dimension 3 (Budget Compliance) per `references/scoring.md`.
+
+**STOP.** Present budget findings. One issue at a time for over-budget assets.
+
+---
+
+## Phase 4: Style Consistency Detection
+
+**Important:** You detect deviations. You do not judge quality. Read `references/gotchas.md` item #3 before proceeding.
+
+If no art style reference was provided in Phase 0:
+- Limit to internal consistency checks (compare same-category assets against each other)
+- Flag: "No art style reference provided. Checking internal consistency only. For full style review, provide an art bible or 3 representative assets."
+
+For each asset category present:
+1. Select representative asset as baseline (most common style in the category)
+2. Compare all others in the category against baseline
+3. For each deviation found, note:
+   - Which asset
+   - Which dimension: color temperature / detail level / line weight / scale / lighting direction / proportions
+   - How it deviates (be specific: "warmer color temperature" not "different style")
+4. Count total deviations
+
+Score dimension 4 (Style Consistency Detection) per `references/scoring.md`.
+
+Confidence on all style observations: LOW. Deviations may be intentional. Present as observations, not verdicts.
+
+**STOP.** Present style findings. Ask about each deviation: "Is this intentional?"
+
+---
+
+## Phase 5: Pipeline Health
+
+Reference: `references/pipeline-checks.md`
+
+Run through applicable checks from the pipeline checks reference:
+1. Import settings consistency (same-type assets should share settings)
+2. Unused asset detection (assets in project but never referenced)
+3. Duplicate detection (same content, different names)
+4. Broken references (materials pointing to missing textures, etc.)
+5. Source file separation (already checked in Phase 1, summarize here)
+6. Atlas/sprite sheet efficiency (if applicable)
+
+Score dimensions 5, 6, and 7 (Pipeline Automation, Redundancy, Documentation) per `references/scoring.md`.
+
+**STOP.** Present pipeline findings. One issue at a time.
+
+---
+
+## Phase 6: Forcing Questions
+
+Apply questions from `references/gotchas.md`. At minimum Q1 (platform target) and Q2 (largest assets).
+
+If platform target was already established in Phase 0, skip Q1 and apply Q3 (naming convention documentation) or Q4 (pipeline traceability) instead.
+
+**STOP** after each question.
+
+---
+
+## Phase 7: Score & Verdict
+
+Apply the 7-dimension rubric from `references/scoring.md`:
 
 ```
-Budget Check:
-  Total texture memory:   ___MB / ___MB budget
-  Total mesh memory:      ___MB / ___MB budget
-  Audio memory:           ___MB / ___MB budget
-  Build size:             ___MB / ___MB target
+Asset Pipeline Review: [Project/Scope]
+═══════════════════════════════════════════
+Platform: [target]
+Mode: [Full / New / Category / Budget]
 
-  Over budget? [YES/NO]
-  Largest assets: [list top 5 by size]
+  Naming & Organization:     _/2
+  Format Compliance:         _/2
+  Budget Compliance:         _/2
+  Style Consistency:         _/2  (deviations: N)
+  Pipeline Automation:       _/2
+  Redundancy:                _/2
+  Documentation:             _/2
+  ─────────────────────────
+  TOTAL:                     _/14  — [CLEAN/ACCEPTABLE/NEEDS_WORK/AT_RISK/BLOCKED]
+
+Top 3 Pipeline Issues:
+  1. [most impactful — specific metric]
+  2.
+  3.
+═══════════════════════════════════════════
 ```
 
-## Section 4: Style Consistency (weight: 25%)
+---
 
-- All assets from same style family?
-- Color palette adherence?
-- Detail level consistent? (one asset hyper-detailed, another flat = mismatch)
-- Lighting baked consistently?
-- Scale consistent? (1 unit = 1 meter across all assets?)
+## Action Triage
 
-⚠️ AI confidence on style judgment: 35% — this section needs human art director review.
+### AUTO
+- Flag naming violations against detected convention
+- Flag missing mipmaps on 3D textures
+- Flag wrong format for platform (e.g., uncompressed PNG on mobile)
+- Flag duplicate assets (same content, different names)
+- Flag unused assets in build
+- Flag oversized textures exceeding per-object budget
 
-## Section 5: Pipeline Health (weight: 15%)
+### ASK (one at a time)
+- Style deviations — could be intentional (boss characters, hero props)
+- Budget allocation priorities — which over-budget assets to fix first
+- Format tradeoffs — quality vs size when both are reasonable
+- Naming convention choice — when no convention exists, recommend but don't impose
 
-- Import settings consistent across similar assets?
-- Automation in place? (texture compression, atlas generation, sprite packing)
-- Asset dependencies mapped? (which assets depend on which?)
-- Unused assets identified? (assets in project but not referenced)
+### ESCALATE
+- Total memory footprint >2x platform budget — needs engineering and art lead
+- No naming convention detectable and >50 assets — needs team alignment
+- No art style reference available and style deviations detected — needs art director
+- Build size >2x target — needs project-level scope discussion
+- Source files mixed into build — may be shipping debug/source content
 
-## AUTO/ASK/ESCALATE
-
-- **AUTO:** Flag naming violations, oversized assets, missing mipmaps
-- **ASK:** Style consistency judgment, budget allocation priorities
-- **ESCALATE:** Build size >2x budget, art style fundamentally inconsistent, missing critical assets
-
-## Anti-Sycophancy
-
-Forbidden:
-- ❌ "Beautiful assets"
-- ❌ "High-quality art"
-- ❌ "Professional look"
-
-Instead: "5 textures exceed 2048x2048 on a mobile target. Total texture memory 180MB vs 64MB budget. Top offender: `bg_forest_panorama.png` at 4096x4096 (32MB)."
+---
 
 ## Completion Summary
 
 ```
-Asset Review:
-  Assets checked: ___
-  Naming issues: ___
-  Spec violations: ___
-  Budget status: [under/at/over] (___MB / ___MB)
-  Style concerns: ___ (⚠️ needs art director confirmation)
-  STATUS: DONE / DONE_WITH_CONCERNS / BLOCKED
+/asset-review complete
+
+Scope: [Full / New / Category / Budget]
+Platform: [target]
+Assets checked: N
+Score: _/14 — [CLEAN/ACCEPTABLE/NEEDS_WORK/AT_RISK/BLOCKED]
+
+Naming issues: N
+Format violations: N
+Budget overruns: N (total: _MB over)
+Style deviations: N (needs art director confirmation)
+Pipeline issues: N
+
+Top issue: [the single most impactful finding]
+
+Status: DONE / DONE_WITH_CONCERNS / BLOCKED
+
+Next: Fix top issue → re-run /asset-review to verify
+      Or: /game-visual-qa for in-engine visual review
+      Or: /game-eng-review for architecture review
 ```
 
 ## Save Artifact
@@ -119,10 +320,10 @@ echo "Saving to: $_PROJECTS_DIR/${_USER}-${_BRANCH}-asset-review-${_DATETIME}.md
 
 Write to `$_PROJECTS_DIR/{user}-{branch}-asset-review-{datetime}.md`. Supersedes prior if exists.
 
-Discoverable by: /game-ship, /game-visual-qa
+Discoverable by: /game-ship, /game-visual-qa, /game-eng-review
 
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"asset-review","timestamp":"TIMESTAMP","status":"STATUS","assets_checked":N,"issues":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"{{SKILL_NAME}}","timestamp":"TIMESTAMP","status":"STATUS","assets_checked":N,"score":N,"verdict":"VERDICT","top_issue":"ISSUE","commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/asset-review/references/benchmarks.md
+++ b/skills/asset-review/references/benchmarks.md
@@ -1,0 +1,93 @@
+# Asset Review — Per-Asset Benchmarks
+
+> **For platform-level budgets** (total memory, frame budget, draw calls), see
+> `game-eng-review/references/performance-budgets.md`. This file covers
+> **per-asset guidelines** only.
+
+## Texture — Max Size Per Object Type
+
+| Object Type | Mobile (low) | Mobile (high) | PC / Console | Web/WebGL |
+|-------------|-------------|---------------|-------------|-----------|
+| Hero character | 1024x1024 | 2048x2048 | 4096x4096 | 1024x1024 |
+| NPC / secondary | 512x512 | 1024x1024 | 2048x2048 | 512x512 |
+| Environment prop | 256x256 | 512x512 | 1024x1024 | 256x256 |
+| Background / skybox | 1024x1024 | 2048x2048 | 4096x4096 | 1024x1024 |
+| UI element | 128-512 | 256-1024 | 512-2048 | 128-512 |
+| VFX / particle | 128x128 | 256x256 | 512x512 | 128x128 |
+| Tilemap tile | 32-64 | 64-128 | 128-256 | 32-64 |
+
+## Texture — Recommended Formats
+
+| Platform | Opaque | With Alpha | UI / Lossless | Normal Map |
+|----------|--------|-----------|--------------|------------|
+| Mobile (Android) | ETC2 / ASTC 6x6 | ASTC 4x4 | PNG (small) | ASTC 4x4 |
+| Mobile (iOS) | ASTC 6x6 | ASTC 4x4 | PNG (small) | ASTC 4x4 |
+| PC / Console | BC7 | BC7 | BC7 / PNG | BC5 |
+| Web/WebGL | Basis / KTX2 | Basis / KTX2 | PNG | Basis |
+
+## Texture — Compression Ratio Guidelines
+
+| Format | Approximate Ratio vs RGBA32 | Bits/Pixel |
+|--------|----------------------------|------------|
+| RGBA32 (uncompressed) | 1x (baseline) | 32 |
+| ASTC 4x4 | 4x smaller | 8 |
+| ASTC 6x6 | 7x smaller | 3.56 |
+| BC7 | 4x smaller | 8 |
+| BC1/DXT1 (no alpha) | 8x smaller | 4 |
+| ETC2 RGB | 6x smaller | 4 |
+| PNG (disk only) | varies | lossless |
+
+Rule of thumb: if an asset uses >4 bits/pixel on mobile, it needs justification.
+
+## Mesh — Poly Budget Per Object
+
+| Object Type | Mobile (low) | Mobile (high) | PC / Console |
+|-------------|-------------|---------------|-------------|
+| Hero character | 3-5K tris | 10-20K tris | 30-100K tris |
+| NPC / secondary | 1-3K tris | 5-10K tris | 15-50K tris |
+| Environment prop (small) | 100-500 tris | 500-2K tris | 2-10K tris |
+| Environment prop (large) | 500-2K tris | 2-5K tris | 5-20K tris |
+| Vehicle | 3-8K tris | 10-25K tris | 30-80K tris |
+| Foliage instance | 50-200 tris | 200-500 tris | 500-2K tris |
+
+## Mesh — LOD Expectations
+
+| Platform | LOD levels expected | LOD0 → LOD1 reduction |
+|----------|--------------------|-----------------------|
+| Mobile | 1-2 LODs | 50% tri reduction |
+| PC / Console | 2-4 LODs | 50% per level |
+| Web | 1-2 LODs | 50% tri reduction |
+
+If no LODs exist on any mesh: flag as finding. LODs are expected for any object >1K tris on mobile, >5K tris on PC.
+
+## Atlas / Sprite Sheet Utilization
+
+| Rating | Fill % | Status |
+|--------|--------|--------|
+| Good | >80% | Efficient packing |
+| Acceptable | 60-80% | Minor waste, review layout |
+| Poor | <60% | Significant wasted space — repack or split |
+
+Sprite sheets: max recommended size 2048x2048 on mobile, 4096x4096 on PC. Prefer multiple smaller sheets over one enormous sheet (reduces memory when only a subset is needed).
+
+## Audio — Format Per Use Case
+
+| Use Case | Recommended Format | Sample Rate | Notes |
+|----------|-------------------|-------------|-------|
+| Music / BGM | OGG Vorbis / AAC | 44.1kHz | Streaming, not loaded to memory |
+| Ambient loops | OGG Vorbis | 44.1kHz | Streaming |
+| SFX (short, <1s) | WAV / PCM | 22.05-44.1kHz | Loaded to memory, needs instant playback |
+| SFX (long, >1s) | OGG Vorbis | 44.1kHz | Compressed, streamed or pooled |
+| UI sounds | WAV / PCM | 22.05kHz | Tiny files, instant playback |
+| Voice / dialogue | OGG Vorbis / AAC | 44.1kHz mono | Mono unless spatial |
+
+## Audio — Loudness Guidelines
+
+| Use Case | Target LUFS | Headroom |
+|----------|------------|----------|
+| Music | -16 to -14 LUFS | -1dB peak |
+| SFX | -12 to -10 LUFS | -1dB peak |
+| UI sounds | -18 to -16 LUFS | -1dB peak |
+| Voice | -16 to -14 LUFS | -1dB peak |
+
+All audio assets should be normalized to their category target. Deviation >3 LUFS from category target = flag.

--- a/skills/asset-review/references/gotchas.md
+++ b/skills/asset-review/references/gotchas.md
@@ -1,0 +1,58 @@
+# Asset Review — Gotchas & Anti-Sycophancy
+
+## Claude-Specific Gotchas
+
+1. **Judges art quality instead of pipeline health.** Claude defaults to aesthetic commentary ("beautiful textures," "nice style"). Asset review is pipeline QA — you care about bytes, formats, naming, and budgets. Whether the art is good is the art director's job. You check whether it's correctly formatted, correctly sized, and consistently named.
+
+2. **Fixates on resolution instead of memory footprint.** A 4096x4096 PNG is ~64MB uncompressed. The same texture as ASTC 4x4 is ~16MB. Resolution alone tells you nothing — format and compression determine actual memory cost. Always report memory footprint, not just pixel dimensions.
+
+3. **Treats all inconsistency as a bug.** Intentional style variation exists. Boss characters are deliberately more detailed than fodder enemies. Hero props have higher budgets than background clutter. UI elements use different resolution rules than 3D textures. Ask whether a deviation is intentional before flagging it as an error.
+
+4. **Ignores platform context.** A 4K texture is fine on PC, catastrophic on mobile. A 100K-tri mesh is modest on console, enormous on WebGL. Every budget check must be evaluated against the target platform. If no platform target is established, that is finding #1 — not something to skip past.
+
+5. **Skips audio assets entirely.** Claude gravitates toward visual and mesh assets because they have more obvious metrics. Audio assets have their own format, bitrate, sample rate, and loudness requirements. Check them explicitly — they are assets too.
+
+6. **Confuses asset-review scope with game-visual-qa scope.** Asset review checks raw files in the pipeline (formats, sizes, naming, budgets). Game-visual-qa checks rendered output in-engine (visual bugs, rendering artifacts, style coherence on screen). If you find yourself talking about how something looks in a screenshot, you've left your lane.
+
+## Anti-Sycophancy Protocol
+
+### Forbidden Phrases
+- "Beautiful assets"
+- "High-quality art"
+- "Professional look"
+- "Clean art style"
+- "Well-crafted textures"
+- "Nice models"
+
+### Required Instead — always cite specific pipeline metrics
+```
+BAD:  "Beautiful textures with a consistent art style."
+GOOD: "42 textures checked. 3 exceed platform budget (bg_forest_01.png: 32MB,
+       fx_explosion_sheet.png: 18MB, ui_world_map.png: 24MB). Naming convention
+       (snake_case with type prefix) followed by 38/42 assets. 4 violations:
+       ForestBG.png, explosionFX.png, WorldMap_UI.png, tree02.png."
+
+BAD:  "The models are well-optimized."
+GOOD: "12 meshes checked against mobile-high budget. 11/12 within per-object
+       budget (2-5K tris for props). 1 over: env_fountain.fbx at 8.2K tris
+       (budget: 5K for environment props). LOD0 only — no LOD chain present
+       on any mesh."
+```
+
+## Forcing Questions
+
+**Q1:** "What is your target platform? If you haven't decided, every budget number I give you is meaningless — and that's finding #1."
+
+**STOP.** Wait for answer. No platform target = no meaningful review.
+
+**Q2:** "Show me your 5 largest assets by file size. Are any of them background elements that could be lower resolution without anyone noticing?"
+
+**STOP.** Wait for answer. This catches the most common budget waste.
+
+**Q3:** "If a new artist joins tomorrow, where is the naming convention documented? If nowhere, every asset from now on is a consistency gamble."
+
+**STOP.** Wait for answer. Undocumented conventions decay fast.
+
+**Q4:** "Pick any asset at random. Can you trace it from source file to game-ready file to in-engine reference? If not, your pipeline has gaps."
+
+**STOP.** Wait for answer. Tests pipeline traceability.

--- a/skills/asset-review/references/naming-conventions.md
+++ b/skills/asset-review/references/naming-conventions.md
@@ -1,0 +1,75 @@
+# Asset Review — Naming Conventions
+
+## Common Patterns
+
+### 1. snake_case with Type Prefix
+```
+tex_hero_knight_diffuse.png
+mdl_env_tree_oak_01.fbx
+sfx_ui_button_click.wav
+ui_hud_health_bar.png
+```
+Most common in Unity projects. Type prefix makes filtering easy.
+
+### 2. PascalCase with Category Suffix
+```
+HeroKnight_Diffuse.png
+TreeOak01_Mesh.fbx
+ButtonClick_SFX.wav
+HealthBar_HUD.png
+```
+Common in Unreal projects. Matches engine naming conventions.
+
+### 3. Flat Tag System
+```
+hero-knight-diffuse.png
+env-tree-oak-01.fbx
+ui-btn-click.wav
+hud-health-bar.png
+```
+Common in web/indie projects. Simple but can get ambiguous.
+
+## Detection Heuristic
+
+To identify which convention a project uses:
+1. Sample 20 assets from different categories
+2. Check: are >80% consistent in case style? (snake_case / PascalCase / kebab-case)
+3. Check: is there a prefix or suffix pattern for type/category?
+4. Check: are numeric suffixes consistent? (01 vs 1 vs _v1)
+5. If <60% consistency: no convention detected — flag as finding
+
+## Common Violations to Flag
+
+| Violation | Example | Why it matters |
+|-----------|---------|---------------|
+| Mixed case styles | `hero_knight.png` + `TreeOak.fbx` | Breaks sorting, search, automation |
+| Missing type indicator | `knight.png` (texture? sprite? UI?) | Can't filter by type |
+| Spaces in names | `Hero Knight.png` | Breaks CLI tools, scripts, some engines |
+| Special characters | `hero@2x.png`, `tree (1).fbx` | Platform-dependent, fragile |
+| Inconsistent numbering | `tree01` + `rock1` + `bush_v2` | Confusing, hard to batch process |
+| No variant indicator | `knight.png` + `knight.png` (different folders) | Ambiguous, merge conflicts |
+
+## Folder Structure Standards
+
+Assets should be organized by ONE consistent principle:
+
+**By Type:**
+```
+assets/textures/characters/
+assets/textures/environment/
+assets/models/characters/
+assets/models/environment/
+assets/audio/sfx/
+assets/audio/music/
+```
+
+**By Feature/Scene:**
+```
+assets/level_01/textures/
+assets/level_01/models/
+assets/characters/hero/
+assets/characters/enemies/
+assets/ui/main_menu/
+```
+
+Either works. Mixing both in the same project = violation. Source files (PSD, Blend, FBX source) should live in a separate `_source/` or `raw/` directory, not alongside game-ready assets.

--- a/skills/asset-review/references/pipeline-checks.md
+++ b/skills/asset-review/references/pipeline-checks.md
@@ -1,0 +1,64 @@
+# Asset Review — Pipeline Checks
+
+## Automated Checks
+
+These checks can be performed by examining the project file structure and asset metadata.
+
+### 1. Unused Asset Detection
+- List all assets in the project directory
+- Cross-reference with scene/level files, prefab references, and code references
+- Assets present in the build but never referenced = unused bloat
+- Flag: number of unused assets + total size of unused assets
+
+### 2. Missing Mipmaps
+- Textures used in 3D rendering should have mipmaps generated
+- UI textures rendered at fixed size do NOT need mipmaps
+- Check engine import settings for mipmap generation flag
+- Flag: 3D textures without mipmaps enabled
+
+### 3. Oversized Textures
+- Compare each texture's dimensions against per-object-type budget (see benchmarks.md)
+- Check actual memory footprint, not just pixel dimensions
+- Flag: textures exceeding budget with file size and recommended size
+
+### 4. Duplicate Detection
+- Files with identical content but different names
+- Files with near-identical content (same dimensions, similar size, different name)
+- Textures that are scaled versions of each other (one may be redundant if mipmaps exist)
+- Flag: suspected duplicates with file sizes and locations
+
+### 5. Broken References
+- Assets referenced in scenes/prefabs that no longer exist on disk
+- Materials referencing missing textures
+- Audio sources pointing to deleted clips
+- Flag: broken references with the referencing file and missing target
+
+### 6. Import Settings Consistency
+- Group assets by type (all character textures, all environment textures, etc.)
+- Check import settings within each group
+- Same-category assets should share: compression format, max size, mipmap settings
+- Flag: assets with import settings that differ from their category peers
+
+### 7. Source File Separation
+- Source files (PSD, Blend, AI, FBX working files) should not be in the game-ready directory
+- Source files should not be included in builds
+- Check for: .psd, .blend, .ai, .sketch, .fig files alongside game assets
+- Flag: source files found in game-ready directories
+
+### 8. Atlas / Sprite Sheet Efficiency
+- Check fill percentage of existing atlases (see benchmarks.md for targets)
+- Identify sprites not included in any atlas that should be
+- Check for oversized atlases (>2048 on mobile, >4096 on PC)
+- Flag: atlases below 60% fill, unatlas'd sprites, oversized sheets
+
+## Check Priority
+
+For a quick audit, run checks in this order (highest impact first):
+1. Oversized textures (biggest budget impact)
+2. Unused assets (easy wins for build size)
+3. Missing mipmaps (visual quality + memory)
+4. Import settings consistency (prevents per-asset surprises)
+5. Duplicates (build size)
+6. Broken references (build errors)
+7. Source file separation (build size)
+8. Atlas efficiency (memory optimization)

--- a/skills/asset-review/references/scoring.md
+++ b/skills/asset-review/references/scoring.md
@@ -1,0 +1,90 @@
+# Asset Review — Scoring
+
+## 7 Dimensions
+
+Each 0-2. Total /14.
+
+### 1. Naming & Organization
+Assets follow a consistent, discoverable naming convention and folder structure.
+
+- **2** = Convention is documented and followed by >90% of assets. Folders organized logically (by type, scene, or feature — consistently). Source files separated from game-ready. No ambiguous names.
+- **1** = Convention is mostly followed (70-90%) but has violations. Folder structure exists but has inconsistencies. Some ambiguous names.
+- **0** = No consistent convention detectable. Mixed casing, mixed separators, no type prefixes. Folders disorganized or flat dump. Finding assets requires guessing.
+
+### 2. Format Compliance
+Assets use the correct format for their type and target platform.
+
+- **2** = All textures use platform-appropriate compressed formats. Models exported in correct format with clean topology. Audio in correct format per use case (compressed for music, uncompressed for short SFX). No wasted alpha channels. Mipmaps generated where needed.
+- **1** = Most formats correct but some assets use suboptimal formats (e.g., uncompressed PNG for 3D textures on mobile, WAV for music). Minor topology issues.
+- **0** = Widespread format problems. Uncompressed textures on mobile. Wrong audio formats. Missing mipmaps. Assets not optimized for target platform.
+
+### 3. Budget Compliance
+Assets fit within per-asset budgets for the target platform.
+
+- **2** = All assets within per-asset budgets. Top 5 largest assets are justified (hero assets, not background clutter). Total footprint within platform budget (reference game-eng-review for platform totals).
+- **1** = Most assets within budget but 1-3 outliers exceed per-asset limits. Total footprint within 120% of budget. Outliers are identifiable and fixable.
+- **0** = Multiple assets exceed per-asset budgets. Total footprint >150% of budget. No awareness of budget constraints. Optimization needed before ship.
+
+### 4. Style Consistency Detection
+Assets from the same category share visual characteristics. Scored by deviation count, NOT by art quality.
+
+- **2** = Across same-category assets (e.g., all environment props, all character portraits), visual characteristics are consistent: color temperature, detail level, line weight, scale, lighting direction. 0-1 deviations detected.
+- **1** = Mostly consistent but 2-4 deviations detected. Deviations may be intentional (ask) — e.g., boss characters deliberately more detailed.
+- **0** = 5+ deviations detected across same-category assets. Mixed art sources likely (marketplace + custom + AI-generated). Needs art director review.
+
+**Important:** You detect and count deviations. You do not judge whether the art style is good. Flag deviations, note which dimension (color/scale/detail/lighting/line weight), and let the art director decide.
+
+### 5. Pipeline Automation
+Import settings, compression, and build steps are automated and consistent.
+
+- **2** = Import settings consistent across similar asset types. Texture compression automated. Atlas/sprite packing configured. Asset dependencies mapped. Build pipeline reproducible.
+- **1** = Some automation but manual steps remain. Import settings mostly consistent but some hand-tuned exceptions. No atlas packing or it's manual.
+- **0** = No automation. Each asset imported with different settings. No compression pipeline. No atlas generation. Manual and fragile.
+
+### 6. Redundancy
+No duplicate, unused, or orphaned assets.
+
+- **2** = No duplicate assets detected. No unused assets in build. No orphaned references. Asset list is clean.
+- **1** = 1-3 suspected duplicates or unused assets. Minor bloat but manageable.
+- **0** = Multiple duplicates with different names. Significant unused assets in build. Orphaned references causing warnings. Build bloat.
+
+### 7. Documentation
+Asset specifications and conventions are documented.
+
+- **2** = Naming convention documented. Per-category budgets documented. Art style reference exists (art bible, reference sheet, or style guide). Pipeline steps documented.
+- **1** = Some documentation exists but incomplete. Convention exists in team knowledge but not written down. Budget targets verbal.
+- **0** = No asset documentation. Convention is "whatever the last person did." No budget targets. No art reference.
+
+## Pipeline Verdict
+
+| Score | Verdict | Description |
+|-------|---------|-------------|
+| 12-14 | **CLEAN** | Pipeline is healthy. Assets are well-organized, within budget, and consistently produced. Ship-ready. |
+| 9-11 | **ACCEPTABLE** | Pipeline works but has minor issues. 1-2 dimensions need attention. Fix before next milestone. |
+| 6-8 | **NEEDS_WORK** | Multiple pipeline issues. Budget overruns, naming chaos, or format problems. Needs dedicated cleanup sprint. |
+| 3-5 | **AT_RISK** | Serious pipeline problems. Assets are inconsistent, over budget, and poorly organized. Shipping risk. |
+| 0-2 | **BLOCKED** | Pipeline is broken. Assets can't be reliably imported, found, or budgeted. Stop adding content and fix the pipeline. |
+
+## Score Template
+
+```
+Asset Pipeline Review: [Project/Scope]
+═══════════════════════════════════════════
+Platform: [target]
+
+  Naming & Organization:     _/2
+  Format Compliance:         _/2
+  Budget Compliance:         _/2
+  Style Consistency:         _/2  (deviations: N)
+  Pipeline Automation:       _/2
+  Redundancy:                _/2
+  Documentation:             _/2
+  ─────────────────────────
+  TOTAL:                     _/14  — [CLEAN/ACCEPTABLE/NEEDS_WORK/AT_RISK/BLOCKED]
+
+Top 3 Pipeline Issues:
+  1. [most impactful — specific metric]
+  2.
+  3.
+═══════════════════════════════════════════
+```


### PR DESCRIPTION
## Summary
- Rewrites `/asset-review` from skeleton (128L, 35%) to production quality (329L template + 380L references)
- Role: **technical artist doing pipeline QA** — checks bytes, triangles, naming, formats. Does NOT judge art quality (per ETHOS.md)
- Adds 5 reference files: gotchas, scoring (7-dimension /14 rubric), benchmarks (per-asset budgets only — platform totals defer to game-eng-review), naming conventions, pipeline checks
- Key design: style consistency is **deviation counting**, not quality judgment. Deviations flagged with measurements; art director decides if intentional
- benchmarks.md references `game-eng-review/references/performance-budgets.md` for platform-level totals, avoids duplication per review notes on #4

Closes #5

## Test plan
- [x] `bun run build` succeeds (all 27 skills generate)
- [x] `bun test` passes 10/11 (1 pre-existing CRLF failure on Windows, not caused by this PR)
- [x] No raw `{{PREAMBLE}}` or `{{SKILL_NAME}}` in generated SKILL.md
- [ ] Manual: invoke `/asset-review` on a project with assets, verify phases and scoring work

🤖 Generated with [Claude Code](https://claude.com/claude-code)