### PR TITLE
feat(game-codex): 3-pass adversarial methodology

### DIFF
--- a/skills/game-codex/SKILL.md
+++ b/skills/game-codex/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: game-codex
-description: "Adversarial second opinion for game code and design. Independent review from a fresh context, focused on game-specific failure modes."
+description: "Adversarial second opinion for game code and design. Independent review from a fresh context, focused on game-specific failure modes. 3-pass exploit methodology (attack surface → systematic scan → creative exploitation), design challenge with fallacy detection, and structured consulting."
 user_invocable: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -87,101 +87,305 @@ _TEL_DUR=$(( _TEL_END - _TEL_START ))
 ```
 
 
+## Load References (BEFORE any interaction)
+
+```bash
+SKILL_DIR="$(find . -path '*skills/game-codex/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/game-codex/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
+
+Read ALL reference files now:
+- `references/exploit-taxonomy.md` — 10 exploit categories with examples, attack recipes, severity calibration
+- `references/attack-by-game-type.md` — priority matrix: which categories matter for SP/competitive/co-op/live-service
+- `references/design-fallacies.md` — 10 game design fallacies for Mode B challenge methodology
+- `references/gotchas.md` — Claude-specific adversarial mistakes, anti-sycophancy protocol, push-back cadence
+
+---
+
 # /game-codex: Adversarial Second Opinion
 
 Independent adversarial review in a clean context. No access to prior review results — prevents confirmation bias.
 
-## Modes
+---
 
-AskUserQuestion: Which mode?
-- **A) Review** — Adversarial code review (find what /gameplay-implementation-review missed)
-- **B) Challenge** — Challenge a design decision or architecture choice
-- **C) Consult** — Fresh perspective on a stuck problem
+## Step 0: Scope & Game Type Classification
+
+AskUserQuestion:
+1. **Re-ground:** "Reviewing [project] on branch [branch] for adversarial analysis."
+2. **Simplify:** "I'll attack your code/design like a cheater, speedrunner, and hostile QA tester. First I need to know what kind of game this is and what you want me to attack."
+3. **Recommend:** Based on context, recommend the most likely mode.
+4. **Options:**
+   - **A) Adversarial Code Review** — 3-pass exploit scan on current diff (find what /gameplay-implementation-review missed)
+   - **B) Challenge** — steelman-then-attack a design decision or architecture choice
+   - **C) Consult** — fresh perspective on a stuck problem, from 5 different angles
+
+**Game type** (determines exploit priority from `attack-by-game-type.md`):
+   - **SP** — Single-player
+   - **CMP** — Competitive multiplayer
+   - **CO** — Co-op
+   - **LS** — Live-service
+
+Record: mode (A/B/C) and game type (SP/CMP/CO/LS).
+
+**STOP.** Wait for mode and game type selection before proceeding.
+
+---
 
 ## Mode A: Adversarial Code Review
+
+**Adversarial mindset (operate in this frame for all of Mode A):**
+
+> You are a chaos engineer, a cheater, and a QA tester who hates this game.
+> Assume every player input is malicious. Assume every network message is forged.
+> Assume every save file has been hex-edited. Assume every timing window will be found.
+>
+> No compliments. No "looks good." Just the problems.
+
+### A.1: Attack Surface Mapping (Pass 1)
 
 ```bash
 _BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "HEAD~1")
 git diff "$_BASE"...HEAD
 ```
 
-**Adversarial prompt (operate in this mindset):**
+Classify the diff against the exploit taxonomy (from `references/exploit-taxonomy.md`).
 
-> You are a chaos engineer, a cheater, and a QA tester who hates this game.
-> Find: race conditions, desync exploits, save corruption vectors, memory leaks,
-> frame budget violations, input edge cases, physics exploits, economy exploits,
-> progression skips, and silent data loss paths.
->
-> Assume every player input is malicious. Assume every network message is forged.
-> Assume every save file has been hex-edited.
->
-> No compliments. No "looks good." Just the problems.
+For each changed file/function, determine:
+1. Which of the 10 exploit categories could this code be vulnerable to?
+2. What is the priority for this game type? (from `references/attack-by-game-type.md`)
+3. What's the attack surface area? (small = isolated utility, large = touches state/economy/networking)
 
-**Game-specific attack vectors:**
-- Frame timing: What happens at 15 FPS? At 300 FPS? At variable frame rate?
-- Input spam: What if player mashes all buttons simultaneously?
-- Save scumming: Can player save-load to guarantee outcomes?
-- Network: What if client lies about position/damage/inventory?
-- Economy: Can player duplicate items/currency through timing exploits?
-- Progression: Can player skip content or reach endgame early?
-- Memory: What happens after 4 hours of play? 8 hours? Does memory grow?
+Output an **attack surface map** — a ranked list of what to investigate:
 
-**Game Exploit Taxonomy (check each category):**
+```
+Attack Surface Map:
+1. [file/function] — [category] — Priority: [C/H/M/L] — Surface: [small/medium/large]
+2. ...
+```
 
-| Category | Attack | Example |
-|----------|--------|---------|
-| **Speed exploit** | Manipulate game speed/frame rate | Uncapping FPS makes physics faster, speed run |
-| **Duplication** | Clone items/currency via timing | Open two menus → buy + sell simultaneously → infinite gold |
-| **State corruption** | Force invalid state via input sequence | Die during screen transition → respawn with boss loot + full health |
-| **Progression skip** | Reach content without prerequisites | Clip through wall → skip tutorial → access endgame area |
-| **Economy abuse** | Generate resources faster than intended | Restart level → keep rewards → repeat (no cooldown on farm) |
-| **PvP cheat** | Client-authoritative gameplay advantage | Client reports "I hit you for 999 damage" → server trusts it |
-| **Save manipulation** | Edit save file for advantage | Save before gacha pull → reload if bad result (save scumming) |
-| **Determinism break** | Different outcomes on different machines | Float precision → physics behaves differently → replay desync |
-| **Social exploit** | Abuse multiplayer social systems | Gift → trade → return gift → net positive (circular trade) |
-| **Content leak** | Access unreleased content | Data mine asset files → spoil future content → community outrage |
+Filter: investigate Critical and High priority categories. Scan Medium. Skip Low unless the diff directly touches that category.
 
-**For each exploit found, rate:**
-- **Severity:** cosmetic / advantage / game-breaking
-- **Effort:** trivial (any player) / moderate (savvy player) / hard (requires tools)
-- **Detectability:** obvious in logs / detectable with analytics / undetectable
+**Triage:** AUTO — generate attack surface map without asking. Present map to user.
+**STOP.** Present attack surface map. One AskUserQuestion: "Proceed with systematic scan of [N] attack surfaces?"
+
+### A.2: Systematic Exploit Scan (Pass 2)
+
+For each attack surface from Pass 1 (Critical first, then High):
+
+1. Follow the **attack recipe** from `references/exploit-taxonomy.md` for that category
+2. Trace data flow: what feeds into this code? What does this code feed into?
+3. Test each recipe step mentally against the actual code
+4. For each finding, compute threat score:
+
+**Threat score formula:**
+```
+threat_score = severity × likelihood × detectability_inverse
+
+severity:       1 = cosmetic, 2 = minor advantage, 3 = significant advantage, 4 = game-breaking
+likelihood:     1 = requires tools/expertise, 2 = savvy player finds it, 3 = common player finds it, 4 = unavoidable/obvious
+detect_inverse: 1 = obvious in logs, 2 = detectable with analytics, 3 = undetectable
+```
+
+Maximum score: 4 × 4 × 3 = 48. Thresholds:
+- Score 1-8: LOW — document, fix when convenient
+- Score 9-15: MEDIUM — fix before next release
+- Score 16-31: HIGH — fix before merge
+- Score 32-48: CRITICAL — block merge, fix immediately
+
+**Triage per finding:**
+- AUTO (score < 9): Document finding, include in final report
+- ASK (score 9-31): Present finding with attack path, ask user to confirm priority
+- ESCALATE (score ≥ 32): Flag immediately, recommend blocking merge
+
+Present ONE finding at a time. For each:
+```
+FINDING: [title]
+Category: [exploit category]
+Attack path: [step-by-step how a player exploits this]
+Threat score: [severity] × [likelihood] × [detect_inverse] = [total] ([LOW/MEDIUM/HIGH/CRITICAL])
+Recommendation: [specific fix]
+```
+
+**STOP.** One finding per AskUserQuestion. User confirms, disputes, or accepts risk.
+
+### A.3: Creative Exploitation (Pass 3)
+
+After systematic scan is complete, do one freeform pass:
+
+1. **Think like a speedrunner:** What's the fastest path through this code that wasn't intended?
+2. **Think like a cheater:** What's the easiest value to manipulate for maximum advantage?
+3. **Think like a griefer:** How can this be used to ruin other players' experience?
+4. **Exploit chains:** Can two low-severity findings combine into a high-severity exploit? Trace interactions between findings from Pass 2.
+
+This pass is for findings the systematic taxonomy wouldn't catch — emergent exploits, creative abuse, and unintended interactions.
+
+**Triage:** AUTO — present any new findings using the same format and scoring as Pass 2.
+**STOP.** Present creative exploitation findings (if any). "Proceed to threat assessment?"
+
+### A.4: Threat Assessment Output
+
+Compile all findings into a ranked threat table:
+
+```
+Threat Assessment: [project] @ [branch]
+Game type: [SP/CMP/CO/LS]
+Commit: [hash]
+
+| # | Finding | Category | Score | Rating | Status |
+|---|---------|----------|-------|--------|--------|
+| 1 | [title] | [cat]    | [N]   | CRIT   | OPEN   |
+| 2 | [title] | [cat]    | [N]   | HIGH   | OPEN   |
+| ...                                                |
+
+Aggregate risk: [LOW / MEDIUM / HIGH / CRITICAL]
+```
+
+**Aggregate risk formula:**
+- If ANY finding ≥ 32 → CRITICAL
+- Else if ANY finding ≥ 16 → HIGH
+- Else if SUM of all scores > 40 → HIGH
+- Else if ANY finding ≥ 9 → MEDIUM
+- Else → LOW
+
+---
 
 ## Mode B: Challenge
 
-Present the decision to challenge. Then:
+Steelman-then-attack methodology. User presents a design decision or architecture choice to challenge.
 
-1. **Steel-man** the current decision (strongest argument FOR it)
-2. **Attack** with 3 specific failure scenarios
-3. **Alternative** — propose a fundamentally different approach
-4. **Verdict:** Current decision stands / Needs revision / Fundamentally wrong
+### B.1: Understand the Decision
+
+AskUserQuestion: "What decision do you want me to challenge? Include context: what alternatives were considered, why this was chosen, what constraints exist."
+
+**STOP.** Wait for the decision to challenge.
+
+### B.2: Steelman
+
+Present the STRONGEST possible argument FOR the current decision. Be genuine — find the real reasons this was a defensible choice. This is not a straw man to knock down.
+
+### B.3: Attack with Fallacies Check
+
+Check the decision against each of the 10 design fallacies from `references/design-fallacies.md`. For each fallacy that applies:
+1. Name the fallacy
+2. Explain specifically how it applies to THIS decision
+3. Provide the counter-evidence
+
+Then construct 3 structured failure scenarios:
+
+```
+Failure Scenario [N]:
+  Trigger: [what goes wrong]
+  Chain: [how it cascades]
+  Player impact: [what players experience]
+  Recovery cost: [how hard to fix after launch]
+```
+
+### B.4: Alternative + Verdict
+
+1. **Alternative:** Propose a fundamentally different approach (not a variation of the same idea)
+2. **Verdict:** One of:
+   - **STANDS** — current decision is defensible, attack found no critical flaws
+   - **NEEDS REVISION** — core idea is sound but specific aspects should change: [list]
+   - **FUNDAMENTALLY WRONG** — decision is based on a fallacy or incorrect assumption: [which one]
+
+**Triage:**
+- AUTO: Steelman, fallacy check, failure scenarios
+- ASK: Present verdict and alternative
+- ESCALATE: If decision is fundamentally wrong AND high impact (affects core loop or monetization)
+
+**STOP.** Present verdict. One AskUserQuestion with verdict and recommended action.
+
+---
 
 ## Mode C: Consult
 
-Present the problem. Then:
+Fresh perspective on a stuck problem. User presents what they're stuck on.
 
-1. **Reframe** — Is this actually the right problem to solve?
-2. **3 approaches** — Each from a different angle (not variations of the same idea)
-3. **Recommendation** with reasoning
+### C.1: Understand the Problem
+
+AskUserQuestion: "What are you stuck on? What have you already tried? What constraints can't change?"
+
+**STOP.** Wait for problem description.
+
+### C.2: Reframe with 5 Lenses
+
+Examine the problem from 5 different perspectives:
+
+1. **Player lens:** What does the player actually experience? Is this even a problem players notice?
+2. **Technical lens:** Is this a design problem disguised as a technical one (or vice versa)?
+3. **Business lens:** What does this mean for retention, monetization, or growth?
+4. **Competitive lens:** How have other games solved this? What can be borrowed or adapted?
+5. **Timeline lens:** Is this a launch problem, a live-ops problem, or a scale problem? Does the solution need to be different at different stages?
+
+### C.3: Steelman Current Approach
+
+Before proposing alternatives, articulate why the current approach (even if stuck) was chosen. What's good about it? What would be lost if it were abandoned?
+
+### C.4: Three Different Approaches
+
+Propose 3 genuinely different solutions (not variations of one idea):
+
+```
+Approach [N]: [name]
+  Core idea: [one sentence]
+  How it works: [2-3 sentences]
+  Preserves: [what's kept from current approach]
+  Sacrifices: [what's given up]
+  Effort: human ~[X] / CC ~[Y]
+  Risk: [main risk]
+```
+
+### C.5: Trade-off Matrix + Recommendation
+
+```
+| Criterion       | Current | Approach 1 | Approach 2 | Approach 3 |
+|-----------------|:---:|:---:|:---:|:---:|
+| Player impact   |  ?  |  ?  |  ?  |  ?  |
+| Effort          |  ?  |  ?  |  ?  |  ?  |
+| Risk            |  ?  |  ?  |  ?  |  ?  |
+| Preserves core  |  ?  |  ?  |  ?  |  ?  |
+```
+
+RECOMMENDATION: Choose [X] because [one-line reason].
+
+**Triage:**
+- AUTO: Reframing, steelman, approach generation
+- ASK: Present trade-off matrix and recommendation
+- ESCALATE: If all approaches have high risk or the problem indicates a deeper architectural issue
+
+**STOP.** Present recommendation. One AskUserQuestion.
+
+---
 
 ## Anti-Sycophancy
 
-This skill is MAXIMALLY adversarial. Forbidden:
-- ❌ Any positive statement about the code or design
-- ❌ "Overall looks good, but..."
-- ❌ "Minor issue..."
-- ❌ Softening language of any kind
+This skill is MAXIMALLY adversarial (Mode A) and rigorously honest (Modes B, C).
 
-Everything is stated as a problem, risk, or question.
+**Read and internalize `references/gotchas.md` before every review.** Key rules:
+
+1. **No positive statements about code or design in Mode A.** Everything is a finding, risk, or question.
+2. **No hedging.** "This is exploitable because [X]" not "This might potentially be an issue."
+3. **No minimizing.** Use threat scores, not words like "minor" or "nitpick."
+4. **Commit to findings.** If uncertain, say "UNVERIFIED — requires [specific test]" not "maybe."
+5. **Follow push-back cadence:** Push once → push with data → escalate → document as accepted risk and move on.
+
+**Forbidden phrases:** "Overall looks solid," "Great work," "Minor issue," "Nitpick," "Just a suggestion," "Looks good but," "Well-designed."
+
+---
 
 ## Completion Summary
 
 ```
 Codex Review:
-  Mode: [review/challenge/consult]
-  Findings: ___ (by severity)
-  Overlaps with prior review: ___ (if known)
-  Unique findings: ___
-  STATUS: DONE
+  Mode: [A: review / B: challenge / C: consult]
+  Game type: [SP/CMP/CO/LS]
+  Findings: ___ total (___ CRITICAL, ___ HIGH, ___ MEDIUM, ___ LOW)
+  Aggregate risk: [LOW / MEDIUM / HIGH / CRITICAL]
+  Exploit categories covered: [list]
+  Unique findings (not in prior reviews): ___
+  STATUS: [DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT]
 ```
 
 ## Save Artifact
@@ -198,5 +402,5 @@ Discoverable by: /game-ship, /gameplay-implementation-review
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"game-codex","timestamp":"TIMESTAMP","status":"STATUS","mode":"MODE","findings":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"game-codex","timestamp":"TIMESTAMP","status":"STATUS","mode":"MODE","findings":N,"aggregate_risk":"RATING","commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/game-codex/SKILL.md.tmpl
+++ b/skills/game-codex/SKILL.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: game-codex
-description: "Adversarial second opinion for game code and design. Independent review from a fresh context, focused on game-specific failure modes."
+description: "Adversarial second opinion for game code and design. Independent review from a fresh context, focused on game-specific failure modes. 3-pass exploit methodology (attack surface → systematic scan → creative exploitation), design challenge with fallacy detection, and structured consulting."
 user_invocable: true
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
@@ -8,101 +8,305 @@ user_invocable: true
 
 {{PREAMBLE}}
 
+## Load References (BEFORE any interaction)
+
+```bash
+SKILL_DIR="$(find . -path '*skills/game-codex/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/game-codex/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
+
+Read ALL reference files now:
+- `references/exploit-taxonomy.md` — 10 exploit categories with examples, attack recipes, severity calibration
+- `references/attack-by-game-type.md` — priority matrix: which categories matter for SP/competitive/co-op/live-service
+- `references/design-fallacies.md` — 10 game design fallacies for Mode B challenge methodology
+- `references/gotchas.md` — Claude-specific adversarial mistakes, anti-sycophancy protocol, push-back cadence
+
+---
+
 # /game-codex: Adversarial Second Opinion
 
 Independent adversarial review in a clean context. No access to prior review results — prevents confirmation bias.
 
-## Modes
+---
 
-AskUserQuestion: Which mode?
-- **A) Review** — Adversarial code review (find what /gameplay-implementation-review missed)
-- **B) Challenge** — Challenge a design decision or architecture choice
-- **C) Consult** — Fresh perspective on a stuck problem
+## Step 0: Scope & Game Type Classification
+
+AskUserQuestion:
+1. **Re-ground:** "Reviewing [project] on branch [branch] for adversarial analysis."
+2. **Simplify:** "I'll attack your code/design like a cheater, speedrunner, and hostile QA tester. First I need to know what kind of game this is and what you want me to attack."
+3. **Recommend:** Based on context, recommend the most likely mode.
+4. **Options:**
+   - **A) Adversarial Code Review** — 3-pass exploit scan on current diff (find what /gameplay-implementation-review missed)
+   - **B) Challenge** — steelman-then-attack a design decision or architecture choice
+   - **C) Consult** — fresh perspective on a stuck problem, from 5 different angles
+
+**Game type** (determines exploit priority from `attack-by-game-type.md`):
+   - **SP** — Single-player
+   - **CMP** — Competitive multiplayer
+   - **CO** — Co-op
+   - **LS** — Live-service
+
+Record: mode (A/B/C) and game type (SP/CMP/CO/LS).
+
+**STOP.** Wait for mode and game type selection before proceeding.
+
+---
 
 ## Mode A: Adversarial Code Review
+
+**Adversarial mindset (operate in this frame for all of Mode A):**
+
+> You are a chaos engineer, a cheater, and a QA tester who hates this game.
+> Assume every player input is malicious. Assume every network message is forged.
+> Assume every save file has been hex-edited. Assume every timing window will be found.
+>
+> No compliments. No "looks good." Just the problems.
+
+### A.1: Attack Surface Mapping (Pass 1)
 
 ```bash
 _BASE=$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null || echo "HEAD~1")
 git diff "$_BASE"...HEAD
 ```
 
-**Adversarial prompt (operate in this mindset):**
+Classify the diff against the exploit taxonomy (from `references/exploit-taxonomy.md`).
 
-> You are a chaos engineer, a cheater, and a QA tester who hates this game.
-> Find: race conditions, desync exploits, save corruption vectors, memory leaks,
-> frame budget violations, input edge cases, physics exploits, economy exploits,
-> progression skips, and silent data loss paths.
->
-> Assume every player input is malicious. Assume every network message is forged.
-> Assume every save file has been hex-edited.
->
-> No compliments. No "looks good." Just the problems.
+For each changed file/function, determine:
+1. Which of the 10 exploit categories could this code be vulnerable to?
+2. What is the priority for this game type? (from `references/attack-by-game-type.md`)
+3. What's the attack surface area? (small = isolated utility, large = touches state/economy/networking)
 
-**Game-specific attack vectors:**
-- Frame timing: What happens at 15 FPS? At 300 FPS? At variable frame rate?
-- Input spam: What if player mashes all buttons simultaneously?
-- Save scumming: Can player save-load to guarantee outcomes?
-- Network: What if client lies about position/damage/inventory?
-- Economy: Can player duplicate items/currency through timing exploits?
-- Progression: Can player skip content or reach endgame early?
-- Memory: What happens after 4 hours of play? 8 hours? Does memory grow?
+Output an **attack surface map** — a ranked list of what to investigate:
 
-**Game Exploit Taxonomy (check each category):**
+```
+Attack Surface Map:
+1. [file/function] — [category] — Priority: [C/H/M/L] — Surface: [small/medium/large]
+2. ...
+```
 
-| Category | Attack | Example |
-|----------|--------|---------|
-| **Speed exploit** | Manipulate game speed/frame rate | Uncapping FPS makes physics faster, speed run |
-| **Duplication** | Clone items/currency via timing | Open two menus → buy + sell simultaneously → infinite gold |
-| **State corruption** | Force invalid state via input sequence | Die during screen transition → respawn with boss loot + full health |
-| **Progression skip** | Reach content without prerequisites | Clip through wall → skip tutorial → access endgame area |
-| **Economy abuse** | Generate resources faster than intended | Restart level → keep rewards → repeat (no cooldown on farm) |
-| **PvP cheat** | Client-authoritative gameplay advantage | Client reports "I hit you for 999 damage" → server trusts it |
-| **Save manipulation** | Edit save file for advantage | Save before gacha pull → reload if bad result (save scumming) |
-| **Determinism break** | Different outcomes on different machines | Float precision → physics behaves differently → replay desync |
-| **Social exploit** | Abuse multiplayer social systems | Gift → trade → return gift → net positive (circular trade) |
-| **Content leak** | Access unreleased content | Data mine asset files → spoil future content → community outrage |
+Filter: investigate Critical and High priority categories. Scan Medium. Skip Low unless the diff directly touches that category.
 
-**For each exploit found, rate:**
-- **Severity:** cosmetic / advantage / game-breaking
-- **Effort:** trivial (any player) / moderate (savvy player) / hard (requires tools)
-- **Detectability:** obvious in logs / detectable with analytics / undetectable
+**Triage:** AUTO — generate attack surface map without asking. Present map to user.
+**STOP.** Present attack surface map. One AskUserQuestion: "Proceed with systematic scan of [N] attack surfaces?"
+
+### A.2: Systematic Exploit Scan (Pass 2)
+
+For each attack surface from Pass 1 (Critical first, then High):
+
+1. Follow the **attack recipe** from `references/exploit-taxonomy.md` for that category
+2. Trace data flow: what feeds into this code? What does this code feed into?
+3. Test each recipe step mentally against the actual code
+4. For each finding, compute threat score:
+
+**Threat score formula:**
+```
+threat_score = severity × likelihood × detectability_inverse
+
+severity:       1 = cosmetic, 2 = minor advantage, 3 = significant advantage, 4 = game-breaking
+likelihood:     1 = requires tools/expertise, 2 = savvy player finds it, 3 = common player finds it, 4 = unavoidable/obvious
+detect_inverse: 1 = obvious in logs, 2 = detectable with analytics, 3 = undetectable
+```
+
+Maximum score: 4 × 4 × 3 = 48. Thresholds:
+- Score 1-8: LOW — document, fix when convenient
+- Score 9-15: MEDIUM — fix before next release
+- Score 16-31: HIGH — fix before merge
+- Score 32-48: CRITICAL — block merge, fix immediately
+
+**Triage per finding:**
+- AUTO (score < 9): Document finding, include in final report
+- ASK (score 9-31): Present finding with attack path, ask user to confirm priority
+- ESCALATE (score ≥ 32): Flag immediately, recommend blocking merge
+
+Present ONE finding at a time. For each:
+```
+FINDING: [title]
+Category: [exploit category]
+Attack path: [step-by-step how a player exploits this]
+Threat score: [severity] × [likelihood] × [detect_inverse] = [total] ([LOW/MEDIUM/HIGH/CRITICAL])
+Recommendation: [specific fix]
+```
+
+**STOP.** One finding per AskUserQuestion. User confirms, disputes, or accepts risk.
+
+### A.3: Creative Exploitation (Pass 3)
+
+After systematic scan is complete, do one freeform pass:
+
+1. **Think like a speedrunner:** What's the fastest path through this code that wasn't intended?
+2. **Think like a cheater:** What's the easiest value to manipulate for maximum advantage?
+3. **Think like a griefer:** How can this be used to ruin other players' experience?
+4. **Exploit chains:** Can two low-severity findings combine into a high-severity exploit? Trace interactions between findings from Pass 2.
+
+This pass is for findings the systematic taxonomy wouldn't catch — emergent exploits, creative abuse, and unintended interactions.
+
+**Triage:** AUTO — present any new findings using the same format and scoring as Pass 2.
+**STOP.** Present creative exploitation findings (if any). "Proceed to threat assessment?"
+
+### A.4: Threat Assessment Output
+
+Compile all findings into a ranked threat table:
+
+```
+Threat Assessment: [project] @ [branch]
+Game type: [SP/CMP/CO/LS]
+Commit: [hash]
+
+| # | Finding | Category | Score | Rating | Status |
+|---|---------|----------|-------|--------|--------|
+| 1 | [title] | [cat]    | [N]   | CRIT   | OPEN   |
+| 2 | [title] | [cat]    | [N]   | HIGH   | OPEN   |
+| ...                                                |
+
+Aggregate risk: [LOW / MEDIUM / HIGH / CRITICAL]
+```
+
+**Aggregate risk formula:**
+- If ANY finding ≥ 32 → CRITICAL
+- Else if ANY finding ≥ 16 → HIGH
+- Else if SUM of all scores > 40 → HIGH
+- Else if ANY finding ≥ 9 → MEDIUM
+- Else → LOW
+
+---
 
 ## Mode B: Challenge
 
-Present the decision to challenge. Then:
+Steelman-then-attack methodology. User presents a design decision or architecture choice to challenge.
 
-1. **Steel-man** the current decision (strongest argument FOR it)
-2. **Attack** with 3 specific failure scenarios
-3. **Alternative** — propose a fundamentally different approach
-4. **Verdict:** Current decision stands / Needs revision / Fundamentally wrong
+### B.1: Understand the Decision
+
+AskUserQuestion: "What decision do you want me to challenge? Include context: what alternatives were considered, why this was chosen, what constraints exist."
+
+**STOP.** Wait for the decision to challenge.
+
+### B.2: Steelman
+
+Present the STRONGEST possible argument FOR the current decision. Be genuine — find the real reasons this was a defensible choice. This is not a straw man to knock down.
+
+### B.3: Attack with Fallacies Check
+
+Check the decision against each of the 10 design fallacies from `references/design-fallacies.md`. For each fallacy that applies:
+1. Name the fallacy
+2. Explain specifically how it applies to THIS decision
+3. Provide the counter-evidence
+
+Then construct 3 structured failure scenarios:
+
+```
+Failure Scenario [N]:
+  Trigger: [what goes wrong]
+  Chain: [how it cascades]
+  Player impact: [what players experience]
+  Recovery cost: [how hard to fix after launch]
+```
+
+### B.4: Alternative + Verdict
+
+1. **Alternative:** Propose a fundamentally different approach (not a variation of the same idea)
+2. **Verdict:** One of:
+   - **STANDS** — current decision is defensible, attack found no critical flaws
+   - **NEEDS REVISION** — core idea is sound but specific aspects should change: [list]
+   - **FUNDAMENTALLY WRONG** — decision is based on a fallacy or incorrect assumption: [which one]
+
+**Triage:**
+- AUTO: Steelman, fallacy check, failure scenarios
+- ASK: Present verdict and alternative
+- ESCALATE: If decision is fundamentally wrong AND high impact (affects core loop or monetization)
+
+**STOP.** Present verdict. One AskUserQuestion with verdict and recommended action.
+
+---
 
 ## Mode C: Consult
 
-Present the problem. Then:
+Fresh perspective on a stuck problem. User presents what they're stuck on.
 
-1. **Reframe** — Is this actually the right problem to solve?
-2. **3 approaches** — Each from a different angle (not variations of the same idea)
-3. **Recommendation** with reasoning
+### C.1: Understand the Problem
+
+AskUserQuestion: "What are you stuck on? What have you already tried? What constraints can't change?"
+
+**STOP.** Wait for problem description.
+
+### C.2: Reframe with 5 Lenses
+
+Examine the problem from 5 different perspectives:
+
+1. **Player lens:** What does the player actually experience? Is this even a problem players notice?
+2. **Technical lens:** Is this a design problem disguised as a technical one (or vice versa)?
+3. **Business lens:** What does this mean for retention, monetization, or growth?
+4. **Competitive lens:** How have other games solved this? What can be borrowed or adapted?
+5. **Timeline lens:** Is this a launch problem, a live-ops problem, or a scale problem? Does the solution need to be different at different stages?
+
+### C.3: Steelman Current Approach
+
+Before proposing alternatives, articulate why the current approach (even if stuck) was chosen. What's good about it? What would be lost if it were abandoned?
+
+### C.4: Three Different Approaches
+
+Propose 3 genuinely different solutions (not variations of one idea):
+
+```
+Approach [N]: [name]
+  Core idea: [one sentence]
+  How it works: [2-3 sentences]
+  Preserves: [what's kept from current approach]
+  Sacrifices: [what's given up]
+  Effort: human ~[X] / CC ~[Y]
+  Risk: [main risk]
+```
+
+### C.5: Trade-off Matrix + Recommendation
+
+```
+| Criterion       | Current | Approach 1 | Approach 2 | Approach 3 |
+|-----------------|:---:|:---:|:---:|:---:|
+| Player impact   |  ?  |  ?  |  ?  |  ?  |
+| Effort          |  ?  |  ?  |  ?  |  ?  |
+| Risk            |  ?  |  ?  |  ?  |  ?  |
+| Preserves core  |  ?  |  ?  |  ?  |  ?  |
+```
+
+RECOMMENDATION: Choose [X] because [one-line reason].
+
+**Triage:**
+- AUTO: Reframing, steelman, approach generation
+- ASK: Present trade-off matrix and recommendation
+- ESCALATE: If all approaches have high risk or the problem indicates a deeper architectural issue
+
+**STOP.** Present recommendation. One AskUserQuestion.
+
+---
 
 ## Anti-Sycophancy
 
-This skill is MAXIMALLY adversarial. Forbidden:
-- ❌ Any positive statement about the code or design
-- ❌ "Overall looks good, but..."
-- ❌ "Minor issue..."
-- ❌ Softening language of any kind
+This skill is MAXIMALLY adversarial (Mode A) and rigorously honest (Modes B, C).
 
-Everything is stated as a problem, risk, or question.
+**Read and internalize `references/gotchas.md` before every review.** Key rules:
+
+1. **No positive statements about code or design in Mode A.** Everything is a finding, risk, or question.
+2. **No hedging.** "This is exploitable because [X]" not "This might potentially be an issue."
+3. **No minimizing.** Use threat scores, not words like "minor" or "nitpick."
+4. **Commit to findings.** If uncertain, say "UNVERIFIED — requires [specific test]" not "maybe."
+5. **Follow push-back cadence:** Push once → push with data → escalate → document as accepted risk and move on.
+
+**Forbidden phrases:** "Overall looks solid," "Great work," "Minor issue," "Nitpick," "Just a suggestion," "Looks good but," "Well-designed."
+
+---
 
 ## Completion Summary
 
 ```
 Codex Review:
-  Mode: [review/challenge/consult]
-  Findings: ___ (by severity)
-  Overlaps with prior review: ___ (if known)
-  Unique findings: ___
-  STATUS: DONE
+  Mode: [A: review / B: challenge / C: consult]
+  Game type: [SP/CMP/CO/LS]
+  Findings: ___ total (___ CRITICAL, ___ HIGH, ___ MEDIUM, ___ LOW)
+  Aggregate risk: [LOW / MEDIUM / HIGH / CRITICAL]
+  Exploit categories covered: [list]
+  Unique findings (not in prior reviews): ___
+  STATUS: [DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT]
 ```
 
 ## Save Artifact
@@ -119,5 +323,5 @@ Discoverable by: /game-ship, /gameplay-implementation-review
 ## Review Log
 
 ```bash
-[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"game-codex","timestamp":"TIMESTAMP","status":"STATUS","mode":"MODE","findings":N,"commit":"COMMIT"}' 2>/dev/null || true
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"{{SKILL_NAME}}","timestamp":"TIMESTAMP","status":"STATUS","mode":"MODE","findings":N,"aggregate_risk":"RATING","commit":"COMMIT"}' 2>/dev/null || true
 ```

--- a/skills/game-codex/references/attack-by-game-type.md
+++ b/skills/game-codex/references/attack-by-game-type.md
@@ -1,0 +1,70 @@
+# Attack Priority by Game Type
+
+Which exploit categories matter most for each game type. Use this to focus adversarial review on the highest-value attack surfaces.
+
+**Priority levels:** C = Critical, H = High, M = Medium, L = Low, — = Not applicable
+
+## Priority Matrix
+
+| Category | Single-player | Competitive MP | Co-op | Live-service |
+|----------|:---:|:---:|:---:|:---:|
+| Speed exploit | M | H | M | H |
+| Duplication | L | H | H | C |
+| State corruption | H | H | H | C |
+| Progression skip | M | L | L | H |
+| Economy abuse | L | M | M | C |
+| PvP cheat | — | C | L | C |
+| Save manipulation | H | L | L | M |
+| Determinism break | L | C | H | C |
+| Social exploit | — | H | M | H |
+| Content leak | L | L | L | C |
+
+---
+
+## Single-player: Top Attack Vectors
+
+**Primary concerns:** Save integrity, state corruption, progression pacing.
+
+1. **State corruption** (H) — No server to validate. Corrupt state means corrupted save, lost progress, softlocks. Player has no recovery path except restart.
+2. **Save manipulation** (H) — Player owns the save file. If not protected, trivially editable. Save scumming bypasses all randomness. For games with permadeath or roguelike elements, this is critical.
+3. **Progression skip** (M) — Less harmful (player only hurts own experience), but breaks intended pacing and can expose unfinished content or crash on unmet assumptions.
+
+**Lower priority:** PvP cheats and social exploits are N/A. Economy abuse is low unless the game has a real-money shop. Duplication matters only if there's trading or leaderboards.
+
+---
+
+## Competitive Multiplayer: Top Attack Vectors
+
+**Primary concerns:** Fairness, client trust, determinism.
+
+1. **PvP cheat** (C) — Any client-authoritative gameplay value is an attack surface. Damage, position, hit detection, ability cooldowns — if the client controls it, cheaters will exploit it.
+2. **Determinism break** (C) — If two clients compute different results, the game state diverges. Replays break, match results become disputed, competitive integrity is destroyed.
+3. **Speed exploit** (H) — Frame-rate-dependent movement or cooldowns give hardware advantages. Players with better machines have faster abilities.
+
+**Lower priority:** Save manipulation is low (server-authoritative). Progression skip is low (matchmaking handles it). Content leak is low (no future content surprise needed).
+
+---
+
+## Co-op: Top Attack Vectors
+
+**Primary concerns:** Shared state integrity, duplication, determinism.
+
+1. **Duplication** (H) — Items shared between players through trade, loot, or gifts. Duplication bugs let one player generate infinite resources for the entire group.
+2. **State corruption** (H) — Shared game state means one player's corruption affects everyone. Host migration adds complexity — what if state is inconsistent between host and clients?
+3. **Determinism break** (H) — Co-op relies on synchronized game state. If players see different enemy positions or damage values, the experience breaks.
+
+**Lower priority:** PvP cheats are low (cooperative, not competitive). Content leak is low. Save manipulation is low if server-hosted.
+
+---
+
+## Live-service: Top Attack Vectors
+
+**Primary concerns:** Economy integrity, competitive fairness, content control.
+
+1. **Economy abuse** (C) — Live-service games monetize through their economy. Any exploit that generates free currency undermines revenue. Duplication, farming exploits, exchange rate manipulation — all are existential threats.
+2. **Duplication** (C) — At scale, duplication bugs crash the economy. Hundreds of players exploiting simultaneously before a patch can cause permanent damage.
+3. **State corruption** (C) — Server-side state corruption at scale affects thousands of players. Rollbacks are expensive and damage trust.
+4. **PvP cheat** (C) — If the game has competitive elements (ranked, esports), cheating drives players away.
+5. **Content leak** (C) — Unreleased content spoilers damage marketing campaigns. Leaked monetization strategies cause community backlash before launch.
+
+**Lower priority:** Save manipulation is medium (server-authoritative, but offline modes may exist). Progression skip is high (can bypass paid content).

--- a/skills/game-codex/references/design-fallacies.md
+++ b/skills/game-codex/references/design-fallacies.md
@@ -1,0 +1,123 @@
+# Game Design Fallacies
+
+10 common fallacies for Mode B (Challenge). Use steelman-then-attack: understand WHY teams fall for each fallacy, THEN identify why it fails.
+
+---
+
+## 1. Sunk Cost: "We already built it"
+
+**Description:** Keeping a feature because effort was invested, not because it serves the game.
+
+**Why teams fall for it:** Throwing away work feels wasteful. Engineers invested weeks. Cutting it means admitting a mistake.
+
+**Why it fails:** Players don't know or care how long something took. A bad feature that took 6 months is still bad. Worse — it has ongoing maintenance cost and cognitive load.
+
+**What to check:** Ask "if we hadn't built this yet, would we start building it today?" If the answer is no, it should be cut or deprioritized.
+
+---
+
+## 2. Feature Creep: "Just one more thing"
+
+**Description:** Continuously adding features without evaluating whether each addition strengthens the core loop.
+
+**Why teams fall for it:** Each feature sounds good in isolation. Saying no feels like lacking ambition. The feature list becomes the measure of progress.
+
+**Why it fails:** Every feature adds complexity, bugs, balance work, and onboarding friction. The game becomes wide but shallow. Players bounce because nothing feels deep enough.
+
+**What to check:** Does this feature strengthen the core loop, or is it adjacent? Can the game ship without it? What's the opportunity cost (what doesn't get polished)?
+
+---
+
+## 3. Complexity Bias: "More systems = more depth"
+
+**Description:** Equating mechanical complexity with engaging depth.
+
+**Why teams fall for it:** Complex systems feel impressive to build. Designers enjoy creating interconnected mechanics. "Depth" is used loosely to mean "lots of stuff."
+
+**Why it fails:** Depth comes from meaningful decisions, not from the number of systems. Chess has simple rules and infinite depth. A game with 15 interlocking systems and no clear decisions is just confusing.
+
+**What to check:** For each system: what decision does the player make? Are there meaningfully different strategies? Can you explain the system to a new player in under 30 seconds?
+
+---
+
+## 4. Success Theater: "Our metrics look good"
+
+**Description:** Optimizing for metrics that don't reflect genuine player satisfaction.
+
+**Why teams fall for it:** Metrics are concrete and defensible in meetings. DAU, session length, and retention numbers feel objective. Questioning metrics feels like questioning data.
+
+**Why it fails:** Players can be retained by addiction loops, sunk cost, or social obligation — not enjoyment. High session length might mean "can't find the exit button." Good metrics with bad sentiment leads to community collapse when a competitor appears.
+
+**What to check:** Are players recommending the game to friends (NPS)? Are they spending voluntarily or through friction? Would they play if there were no daily login rewards?
+
+---
+
+## 5. Platform Mismatch: "It works on PC"
+
+**Description:** Designing for one platform's strengths while targeting another platform's audience.
+
+**Why teams fall for it:** Teams develop on their preferred platform. PC has keyboard + mouse, large screen, long sessions. It's natural to design for the development environment.
+
+**Why it fails:** Mobile players have 3-minute sessions, touch input, interruptions. Console players sit on a couch with a controller. What works with a mouse doesn't work with touch. Session length assumptions are platform-dependent.
+
+**What to check:** What's the target platform's typical session length? Input method? Screen size? Interruption frequency? Does the core loop fit these constraints?
+
+---
+
+## 6. Audience Mismatch: "We're building for gamers like us"
+
+**Description:** Designing for the team's preferences rather than the target audience's needs.
+
+**Why teams fall for it:** Teams are passionate about what they personally enjoy. It's motivating to build the game you want to play. Internal playtests confirm the team likes it.
+
+**Why it fails:** The team is not a representative sample. Experienced developers find different things fun than casual players. Self-selection bias means the team never discovers what their actual audience struggles with.
+
+**What to check:** Who is the target player? Have people matching that profile played the game? What did external playtesters struggle with that the team didn't?
+
+---
+
+## 7. Retention Cargo Cult: "Add daily login rewards"
+
+**Description:** Copying retention mechanics from successful games without understanding why they worked in that context.
+
+**Why teams fall for it:** Successful games use daily rewards, battle passes, and FOMO mechanics. Copying visible patterns feels safe and proven.
+
+**Why it fails:** Retention mechanics amplify existing engagement — they don't create it. Daily rewards on a boring game just remind players that the game is boring. Battle passes without compelling content are a chore, not a hook.
+
+**What to check:** Is the core loop fun without any retention mechanics? Would players return tomorrow if there were no daily rewards? Are you retaining players or trapping them?
+
+---
+
+## 8. Monetization-Gameplay Conflict: "It's just a convenience"
+
+**Description:** Paid advantages disguised as time-saving convenience.
+
+**Why teams fall for it:** "Pay to skip the grind" sounds player-friendly. The team genuinely believes both paths (paying and grinding) are viable. Revenue targets push toward more monetization.
+
+**Why it fails:** If paying is better than playing, the optimal strategy is to not play. The grind is intentionally made worse to push purchases. Players recognize this pattern and resent it. Community trust erodes.
+
+**What to check:** Is the free path genuinely fun, or deliberately tedious? Would the team be comfortable if the payment option didn't exist? Does paying change competitive outcomes?
+
+---
+
+## 9. Scope Optimism: "We can cut later"
+
+**Description:** Assuming features can be removed or reduced later if time runs short.
+
+**Why teams fall for it:** Keeping options open feels prudent. "We'll evaluate at alpha" defers hard decisions. Nobody wants to be the one who killed a feature early.
+
+**Why it fails:** Features become load-bearing. Other systems are built assuming the feature exists. Art assets are created, tutorials reference it, marketing mentions it. Cutting late is 10x harder than cutting early. One-way doors disguised as two-way doors.
+
+**What to check:** If this feature were cut tomorrow, what else breaks? Has anything been built that assumes this feature ships? Is this a two-way door (easily reversible) or a one-way door (costly to undo)?
+
+---
+
+## 10. Uniqueness Fallacy: "Nobody has done this before"
+
+**Description:** Believing an idea is novel when it's actually been tried and failed, or solved differently.
+
+**Why teams fall for it:** Limited exposure to game history. The team hasn't played the failed attempts. Survivorship bias — they only see games that succeeded.
+
+**Why it fails:** Most "novel" ideas have been attempted. The question isn't "has anyone tried this?" but "why didn't it work when they did?" Ignoring prior art means repeating known mistakes.
+
+**What to check:** Search for similar mechanics in released games (including failures). Ask: why might previous teams have abandoned this approach? What evidence suggests this time is different?

--- a/skills/game-codex/references/exploit-taxonomy.md
+++ b/skills/game-codex/references/exploit-taxonomy.md
@@ -1,0 +1,253 @@
+# Exploit Taxonomy
+
+10 categories of game exploits. For each: description, concrete examples, attack recipe (how to test), and severity calibration.
+
+---
+
+## 1. Speed Exploit
+
+**Description:** Manipulating game speed, frame rate, or time step to gain advantage.
+
+**Examples:**
+- Uncapping FPS makes physics tick faster — player moves at 2x speed
+- Slow-motion hack: throttle CPU to reduce tick rate, get more reaction time
+- Fast-forward: speed up client clock to skip wait timers
+- Pause abuse: pause during animation to cancel recovery frames
+- Alt-tab timing: backgrounding app freezes delta-time accumulator, resumes with huge delta
+
+**Attack recipe:**
+1. Check if physics/movement uses `deltaTime` without capping
+2. Look for `Time.timeScale` or equivalent that players can influence
+3. Search for frame-rate-dependent logic (anything multiplied by frame count instead of time)
+4. Test: what happens if `deltaTime` is 0? Negative? 10 seconds?
+5. Check if cooldowns/timers use wall clock vs game time
+
+**Severity calibration:**
+- Cosmetic: animation plays slightly faster (visual only)
+- Advantage: player moves faster than intended, cooldowns shorter
+- Game-breaking: speed run trivializes all content; PvP becomes unplayable
+
+---
+
+## 2. Duplication
+
+**Description:** Cloning items, currency, or resources through timing windows or race conditions.
+
+**Examples:**
+- Open two trade windows simultaneously — item exists in both
+- Drop item + pick up in same frame — inventory has item, ground has copy
+- Disconnect during transfer — rollback gives item back, recipient keeps copy
+- Undo/redo in editor mode duplicates placed objects
+- Save during transfer, reload — both parties have the item
+
+**Attack recipe:**
+1. Find any operation that moves items between containers (inventory, storage, trade, mail)
+2. Check if the operation is atomic (single transaction) or multi-step
+3. Look for "remove from A, add to B" patterns — what if step 2 fails?
+4. Test concurrent operations: can two requests reference the same item?
+5. Check what happens on disconnect/crash mid-operation
+
+**Severity calibration:**
+- Cosmetic: visual duplicate that disappears on refresh
+- Advantage: player gets extra resources, but limited by effort
+- Game-breaking: infinite currency/items, destroys economy
+
+---
+
+## 3. State Corruption
+
+**Description:** Forcing the game into an invalid state through unexpected input sequences or interrupts.
+
+**Examples:**
+- Die during screen transition — respawn with boss loot + full health
+- Open menu during cutscene — cutscene flags never cleared, game stuck
+- Trigger two state changes in same frame — player is both alive and dead
+- Interrupt save with alt-F4 — save file half-written, corrupted
+- Enter area while loading screen is active — collision not loaded yet
+
+**Attack recipe:**
+1. Identify all state machines (player state, game state, UI state, network state)
+2. For each state machine: can external events force a transition during another transition?
+3. Look for boolean flags used as state — two flags can contradict each other
+4. Check interrupt points: what happens if the player dies/disconnects during any operation?
+5. Test rapid input during transitions (loading, cutscenes, menus opening/closing)
+
+**Severity calibration:**
+- Cosmetic: UI shows wrong state briefly, self-corrects
+- Advantage: player bypasses intended restrictions
+- Game-breaking: corrupted save, softlock, unrecoverable state
+
+---
+
+## 4. Progression Skip
+
+**Description:** Reaching content or areas without completing prerequisites.
+
+**Examples:**
+- Clip through wall to skip tutorial and access endgame area
+- Sequence break: complete objectives out of intended order
+- Overflow a counter to wrap around to max level
+- Manipulate quest flags directly (if exposed to client)
+- Use photo mode camera to scout through walls, find unintended paths
+
+**Attack recipe:**
+1. Map all progression gates (level requirements, quest completions, item checks)
+2. Check if gates are enforced server-side or client-side only
+3. Look for collision gaps, out-of-bounds paths, or teleport exploits
+4. Test: can the player reach area B without completing area A's requirements?
+5. Check if progression flags can be set without actually completing the content
+
+**Severity calibration:**
+- Cosmetic: player sees area early but can't interact
+- Advantage: player skips grind, reaches endgame faster
+- Game-breaking: player skips paid content, story makes no sense, other systems assume prerequisites met
+
+---
+
+## 5. Economy Abuse
+
+**Description:** Generating resources faster than intended or exploiting exchange rates.
+
+**Examples:**
+- Restart level, keep rewards, repeat (no cooldown on farming)
+- Buy item in currency A, sell in currency B at profit, convert back (arbitrage)
+- Rounding exploit: 1.5 rounds to 2, buy/sell cycle nets +1 each time
+- Referral/gift system abuse: create alt accounts, gift to main
+- Time-zone exploit: daily rewards reset at midnight per timezone, travel to collect twice
+
+**Attack recipe:**
+1. Map all resource faucets (ways to gain) and sinks (ways to spend)
+2. Check for circular paths: can you convert A→B→C→A at a profit?
+3. Look for rounding in any currency conversion or exchange
+4. Test: what's the fastest loop for gaining resources? Is it faster than intended?
+5. Check cooldown/cap enforcement: are limits client-side or server-side?
+
+**Severity calibration:**
+- Cosmetic: player earns 10% more than intended (minor imbalance)
+- Advantage: player can farm 2-3x faster, progression curve distorted
+- Game-breaking: infinite currency generation, economy collapse, pay-to-win invalidated
+
+---
+
+## 6. PvP Cheat
+
+**Description:** Client-authoritative gameplay giving unfair advantage in competitive play.
+
+**Examples:**
+- Client reports "I hit you for 999 damage" — server trusts it
+- Wallhack: client has all player positions, just hides them visually
+- Aim assist manipulation: modify client input smoothing values
+- Lag switch: intentionally spike latency to become unhittable
+- Ghost peek: exploit camera position vs hitbox mismatch
+
+**Attack recipe:**
+1. Identify what the client is authoritative over (position, damage, hit detection, abilities)
+2. For each client-authoritative value: what if the client lies?
+3. Check if server validates client claims (position deltas, damage ranges, cooldowns)
+4. Look for information leaks: does the client receive data it shouldn't display?
+5. Test: can a modified client send impossible values without rejection?
+
+**Severity calibration:**
+- Cosmetic: slight visual advantage (information leak with no gameplay impact)
+- Advantage: player has edge in competitive play
+- Game-breaking: aimbot/wallhack/damage hack makes competitive play pointless
+
+---
+
+## 7. Save Manipulation
+
+**Description:** Editing save files or exploiting save/load mechanics for advantage.
+
+**Examples:**
+- Save before gacha pull, reload if bad result (save scumming)
+- Hex-edit save file to set inventory/currency to max values
+- Copy save file, load on two devices, duplicate account state
+- Modify timestamps in save to skip time-gated content
+- Delete specific save entries to reset "one-time" rewards
+
+**Attack recipe:**
+1. Check save file format — is it encrypted? Signed? Checksummed?
+2. Look for plain-text or easily-decoded values (JSON, XML, base64)
+3. Test: modify a save value, does the game detect tampering?
+4. Check if save timing is exploitable (save before random event, reload)
+5. For cloud saves: can player force a sync conflict to duplicate items?
+
+**Severity calibration:**
+- Cosmetic: player customizes cosmetics without unlocking
+- Advantage: player bypasses grind or randomness
+- Game-breaking: full progression bypass, all content unlocked instantly
+
+---
+
+## 8. Determinism Break
+
+**Description:** Different outcomes on different machines or playthroughs due to non-deterministic behavior.
+
+**Examples:**
+- Floating-point precision: physics behaves differently on AMD vs Intel
+- Uninitialized memory: behavior depends on what was in memory before
+- Hash map iteration order: gameplay logic depends on dictionary ordering
+- Thread scheduling: race condition causes different outcomes per run
+- Random seed not synchronized in multiplayer — players see different game states
+
+**Attack recipe:**
+1. Search for floating-point comparisons (especially equality checks)
+2. Look for hash maps/dictionaries used in gameplay-critical iteration
+3. Check if random number generation uses synchronized seeds in multiplayer
+4. Look for platform-specific behavior (endianness, float precision, path separators)
+5. Test: run the same replay twice — are results identical?
+
+**Severity calibration:**
+- Cosmetic: particle effects differ slightly between machines
+- Advantage: specific hardware gives better RNG or physics behavior
+- Game-breaking: multiplayer desync, replays don't match, competitive integrity destroyed
+
+---
+
+## 9. Social Exploit
+
+**Description:** Abusing multiplayer social systems for advantage.
+
+**Examples:**
+- Gift → trade → return gift → net positive (circular trade)
+- Report spam: mass-report a player to trigger automated ban
+- Name/chat injection: Unicode tricks, fake system messages
+- Grief mechanics: block doorways, steal loot, team-kill with no penalty
+- Smurf accounts: experienced player in beginner matchmaking
+
+**Attack recipe:**
+1. Map all player-to-player interactions (trade, gift, chat, report, invite, block)
+2. For each interaction: what if one party acts in bad faith?
+3. Check for rate limiting on social actions (reports, gifts, trades per day)
+4. Look for trust assumptions: does the system assume players are cooperative?
+5. Test: can a group of coordinated players exploit the system together?
+
+**Severity calibration:**
+- Cosmetic: funny name tricks, harmless pranks
+- Advantage: free items through gift cycling, boosted rankings
+- Game-breaking: targeted harassment with no recourse, economy manipulation through trade rings
+
+---
+
+## 10. Content Leak
+
+**Description:** Accessing unreleased or hidden content through data mining or client exploitation.
+
+**Examples:**
+- Data mine asset files to find unreleased characters/levels
+- API endpoint enumeration reveals future content
+- Client receives future event data ahead of time (just not displayed)
+- Debug menus or developer tools left in release build
+- String tables contain unreleased quest/dialogue text
+
+**Attack recipe:**
+1. Check what ships in the client build — are future assets included?
+2. Look for debug flags, developer menus, or test commands in release
+3. Check API responses: do they include more data than the client displays?
+4. Search for commented-out features or feature flags in client code
+5. Test: can asset files be opened with standard tools (image viewers, text editors)?
+
+**Severity calibration:**
+- Cosmetic: players know what's coming (mild spoilers)
+- Advantage: players prepare/hoard for upcoming content, market manipulation
+- Game-breaking: major story spoilers destroy launch impact, unreleased monetization strategy leaked causes PR crisis

--- a/skills/game-codex/references/gotchas.md
+++ b/skills/game-codex/references/gotchas.md
@@ -1,0 +1,98 @@
+# Claude-Specific Adversarial Review Gotchas
+
+Common mistakes Claude makes during adversarial game review. Read these BEFORE starting any review to avoid them.
+
+---
+
+## Gotcha 1: Checklist Review Instead of Investigation
+
+**The mistake:** Walking through the exploit taxonomy mechanically — "Speed exploit? No. Duplication? No. State corruption? No." — without actually thinking adversarially about the specific code.
+
+**Why it happens:** The taxonomy provides a comfortable structure. It's easier to check boxes than to reason about exploit chains.
+
+**The fix:** Use the taxonomy to identify WHICH categories are relevant, then switch to creative exploitation mode. Ask: "If I were a cheater looking at this specific code, what would I try first?"
+
+---
+
+## Gotcha 2: Surface-Level Findings, Missing Exploit Chains
+
+**The mistake:** Finding individual issues ("this value isn't validated") without tracing what happens when they're combined ("this unvalidated value feeds into the damage calculation, which is then broadcast to all clients, meaning...").
+
+**Why it happens:** Claude tends to analyze code in isolation. Each function gets its own finding, but the connections between functions are where the real exploits live.
+
+**The fix:** For every finding, ask: "What does this feed into? What feeds into this?" Trace the data flow. The most dangerous exploits combine two benign-looking issues.
+
+---
+
+## Gotcha 3: Severity Inflation
+
+**The mistake:** Rating everything as "game-breaking" or "critical." If every finding is critical, none are.
+
+**Why it happens:** Adversarial mode creates pressure to find serious issues. Mild findings feel like failing the adversarial role. It's safer to over-rate than under-rate.
+
+**The fix:** Use the threat score formula strictly. Be honest about likelihood — "a player could theoretically..." is not the same as "a player will likely..." Severity 1 (cosmetic) and 2 (minor advantage) are valid and useful findings.
+
+---
+
+## Gotcha 4: Game-Type Blindness
+
+**The mistake:** Flagging PvP cheats in a single-player game, or worrying about save manipulation in a server-authoritative live service.
+
+**Why it happens:** The full taxonomy is loaded and Claude applies all categories regardless of context.
+
+**The fix:** ALWAYS classify the game type first (Step 0) and filter through the priority matrix in `attack-by-game-type.md`. Spend time proportional to priority: Critical categories get deep investigation, Low categories get a quick scan.
+
+---
+
+## Gotcha 5: Timing Exploits Are Invisible in Static Review
+
+**The mistake:** Declaring code "safe" because the logic looks correct — while missing that two operations aren't atomic and can be interleaved by concurrent requests.
+
+**Why it happens:** Claude reads code statically. Race conditions, timing windows, and concurrent access patterns are extremely hard to spot without execution context.
+
+**The fix:** Explicitly flag ANY multi-step operation that isn't wrapped in a transaction or mutex. When you see "remove from A, then add to B" — flag it as a potential timing exploit even if you can't prove it. Be transparent: "I cannot verify this through static analysis — requires runtime testing."
+
+---
+
+## Gotcha 6: Hedging Instead of Committing
+
+**The mistake:** "This might potentially be an issue if certain conditions are met..." instead of "This is exploitable. Here's how."
+
+**Why it happens:** Claude's default communication style is cautious and hedge-filled.
+
+**The fix:** In game-codex, commit to your findings. State the exploit, the attack path, and the impact. If you're uncertain, say "UNVERIFIED: [specific thing to test]" — don't hedge the entire finding.
+
+---
+
+## Anti-Sycophancy Protocol
+
+**Forbidden phrases (NEVER use in game-codex):**
+- "Overall the code looks solid"
+- "Great work on..."
+- "Minor issue..." (minimize language)
+- "This is a nitpick, but..."
+- "The architecture is well-designed"
+- "Just a small suggestion..."
+- "Looks good, but..."
+
+**Calibrated alternatives:**
+- Instead of "The code is well-structured but has one issue" → "Finding: [issue]. Threat score: [X]."
+- Instead of "Minor: consider adding validation" → "Missing validation on [field]. Attack: [specific attack]. Threat: [score]."
+- Instead of "Overall looks good" → (say nothing positive — this skill is purely adversarial)
+
+**Acknowledgment calibration (when user pushes back):**
+- If finding is wrong: "Retracted. [Finding] doesn't apply because [reason]. Adjusting threat assessment."
+- If finding is disputed: "Acknowledged. Keeping [finding] at reduced severity because [reasoning]. Recommend testing [specific test]."
+- Do NOT say: "You make a great point" or "That's a really good observation"
+
+---
+
+## Push-Back Cadence
+
+When presenting a finding the developer disagrees with:
+
+1. **First push:** State the finding clearly with the attack path. "This is exploitable because [X]. Attack: [steps]."
+2. **Second push (with data):** If the developer dismisses it, provide a concrete scenario. "Specific scenario: Player does [A], then [B], resulting in [C]. This has been observed in [similar game/pattern]."
+3. **Escalate:** If still dismissed, escalate clearly. "ESCALATE: I've presented this twice with supporting evidence. Recommend [senior dev / security review / playtest] to verify. Documenting as an accepted risk if not addressed."
+
+After the third push, document the finding as "ACCEPTED RISK — developer acknowledged, chose not to address" and move on. Do not keep repeating.


### PR DESCRIPTION
## Summary
- Rewrites `/game-codex` from 123L skeleton (40%) to ~870L total with 4 reference files and a 327L production template
- Adds 3-pass Mode A: Attack Surface Mapping, Systematic Exploit Scan (with threat scoring formula), Creative Exploitation
- Adds Mode B steelman-then-attack with 10 design fallacies, Mode C 5-lens consulting with trade-off matrix
- Adds `references/` directory: exploit-taxonomy.md, attack-by-game-type.md, design-fallacies.md, gotchas.md

## Test plan
- [x] `bun run build` generates SKILL.md successfully
- [x] `bun test` — 10 pass, 1 pre-existing CRLF failure (affects all skills on this Windows worktree, not introduced by this PR)
- [ ] Manual: invoke `/game-codex` Mode A on a real diff, verify 3-pass flow works
- [ ] Manual: invoke `/game-codex` Mode B, verify fallacy detection activates
- [ ] Manual: invoke `/game-codex` Mode C, verify 5-lens reframing works

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)