### PR TITLE
feat(game-eng-review): add reference files and slim template

### DIFF
--- a/skills/game-eng-review/SKILL.md
+++ b/skills/game-eng-review/SKILL.md
@@ -127,25 +127,15 @@ Review a game's technical architecture interactively. Work through each section 
 
 This skill reviews architecture DECISIONS, not code. For code review, use `/gameplay-implementation-review`.
 
-## Anti-Sycophancy Protocol
+## Load References
 
-**FORBIDDEN PHRASES — never use these or any paraphrase:**
-- "Great architecture!"
-- "This is a solid technical foundation"
-- "Good engine choice"
-- "The networking looks robust"
-- "Smart approach to optimization"
-- "This should scale well"
-- "Interesting technical decision"
+Read these reference files before starting the review — they contain scoring rubrics, platform benchmarks, and Claude-specific gotchas:
 
-**CALIBRATED ACKNOWLEDGMENT — use this instead:**
-- Name the specific technical decision and WHY it works for THIS game: "Using ECS for entity management supports the stated 200-unit battle scenes because component iteration is cache-friendly — this is the right data model for that specific scale."
-- If something is genuinely well-architected, describe the mechanical reason it works for the game's specific requirements, never just say it's "good" or "solid."
+- `references/scoring.md` — All 8 section rubrics with mode weight adjustments and scoring notes
+- `references/gotchas.md` — Claude-specific architecture review mistakes, anti-sycophancy protocol, forcing question routing
+- `references/performance-budgets.md` — Frame budgets, draw call limits, memory ceilings, texture sizes, build size limits by platform
 
-**PUSH-BACK CADENCE:**
-1. Push once: State the concern directly with evidence.
-2. Push again: If the response is vague ("we'll optimize later"), ask for the specific benchmark target, profiling plan, and fallback if targets are missed.
-3. Escalate: If still vague after two pushes, flag as ESCALATE — "This needs a concrete performance budget before architecture can be validated."
+> **Anti-sycophancy and push-back cadence:** See `references/gotchas.md`. Follow the forbidden phrases list and push-back cadence for EVERY interaction.
 
 ---
 
@@ -215,17 +205,7 @@ After Step 0 context is established, present the routing via AskUserQuestion:
 
 ## Section 1: Engine & Framework (引擎選型) — Weight: 15%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Fitness for Genre** | 0-3 | 3 = engine's strengths align with game's core requirements (e.g., Unity for mobile 2D, Unreal for high-fidelity 3D). 2 = workable but not optimal. 1 = significant workarounds needed. 0 = engine fundamentally mismatched |
-| **Team Familiarity** | 0-2 | 2 = team has shipped with this engine. 1 = team has prototyped but not shipped. 0 = team has no experience with this engine |
-| **Platform Support** | 0-2 | 2 = engine natively supports all target platforms with proven track record. 1 = supports with known limitations. 0 = requires custom porting work |
-| **Ecosystem & Tooling** | 0-1 | 1 = mature plugin ecosystem, asset store, debugging tools available. 0 = limited ecosystem or team building custom tooling for basics |
-| **License & Cost Risk** | 0-2 | 2 = licensing terms clear, sustainable at projected scale, no revenue share surprises. 1 = some cost risk at scale. 0 = license terms could become prohibitive or are unclear |
-
-**Section 1 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 1. Five criteria: Fitness for Genre (0-3), Team Familiarity (0-2), Platform Support (0-2), Ecosystem & Tooling (0-1), License & Cost Risk (0-2). Total: ___/10.
 
 ### Engine Red Flags
 
@@ -264,36 +244,9 @@ Push until you hear: A named limitation AND a concrete plan. Every engine has we
 
 ## Section 2: Rendering & Performance (渲染與效能) — Weight: 20%
 
-### Frame Budget Model
+Every game has a frame budget. Check the architecture doc against platform-specific targets in `references/performance-budgets.md` (frame budgets, draw call limits, memory ceilings). If the architecture doc does not include a frame budget: **-2 points.** Without a budget, performance is being managed by hope.
 
-Every game has a frame budget. Calculate it explicitly:
-
-```
-Target: 60 FPS → 16.67ms per frame
-Target: 30 FPS → 33.33ms per frame
-
-Budget allocation (typical):
-  Game logic:     3-5ms   (20-30%)
-  Physics:        2-4ms   (12-24%)
-  Rendering:      6-10ms  (36-60%)
-  Audio:          1-2ms   (6-12%)
-  UI:             1-2ms   (6-12%)
-  Headroom:       1-2ms   (buffer for spikes)
-```
-
-If the architecture doc does not include a frame budget: **-2 points.** Without a budget, performance is being managed by hope.
-
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Frame Budget Defined** | 0-2 | 2 = explicit ms budget per system with target FPS. 1 = target FPS stated but no per-system breakdown. 0 = no performance target |
-| **Draw Call Strategy** | 0-2 | 2 = batching/instancing strategy documented, draw call target for worst-case scene. 1 = general awareness but no target. 0 = not addressed |
-| **LOD / Culling** | 0-2 | 2 = LOD strategy with distance thresholds, frustum/occlusion culling plan. 1 = LOD mentioned but no specifics. 0 = not addressed (acceptable for 2D games — score N/A) |
-| **Shader Complexity** | 0-2 | 2 = shader budget per material tier, fallback shaders for low-end. 1 = custom shaders exist but no complexity budget. 0 = no shader strategy |
-| **Memory Budget** | 0-2 | 2 = per-platform memory ceiling with allocation breakdown (textures, meshes, audio, runtime). 1 = total memory target but no breakdown. 0 = no memory planning |
-
-**Section 2 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 2. Five criteria: Frame Budget Defined (0-2), Draw Call Strategy (0-2), LOD/Culling (0-2), Shader Complexity (0-2), Memory Budget (0-2). Total: ___/10.
 
 ### Performance Red Flags
 
@@ -332,9 +285,7 @@ Push until you hear: A graceful degradation strategy. Dynamic resolution? Partic
 
 ## Section 3: Networking Architecture (網路架構) — Weight: 15%
 
-**Skip this section if the game is single-player only.** Score as N/A and redistribute weight.
-
-### Network Model Classification
+**Skip this section if the game is single-player only.** Score as N/A and redistribute weight per mode table in `references/scoring.md`.
 
 First, classify the networking model:
 
@@ -346,17 +297,7 @@ First, classify the networking model:
 | **Turn-Based** | High (async OK) | Low | Low | Hearthstone, chess |
 | **Async/Social** | Very High | Very Low | Low | Clash of Clans attacks, leaderboards |
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Model Fitness** | 0-3 | 3 = network model matches game's latency/bandwidth needs. 2 = workable but suboptimal. 1 = will cause noticeable player-facing issues. 0 = model cannot support core gameplay |
-| **State Synchronization** | 0-2 | 2 = sync strategy documented (what state is authoritative, what is predicted, what is cosmetic). 1 = general sync approach but no state classification. 0 = not addressed |
-| **Latency Handling** | 0-2 | 2 = prediction/rollback/interpolation strategy documented with target latency tolerance. 1 = acknowledged but no specific strategy. 0 = not addressed (for action games, this is -2 effectively) |
-| **Cheat Prevention** | 0-2 | 2 = server-authoritative for game-critical state, client validation documented. 1 = some server authority but gaps identified. 0 = trust-the-client architecture for competitive game |
-| **Failure Modes** | 0-1 | 1 = disconnect handling, reconnect flow, and desync recovery documented. 0 = not addressed |
-
-**Section 3 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 3. Five criteria: Model Fitness (0-3), State Synchronization (0-2), Latency Handling (0-2), Cheat Prevention (0-2), Failure Modes (0-1). Total: ___/10.
 
 ### Networking Red Flags
 
@@ -384,17 +325,7 @@ First, classify the networking model:
 
 ## Section 4: Data & Persistence (資料與存檔) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Save System Design** | 0-3 | 3 = save format documented, versioned, tested for corruption recovery. 2 = save system exists but no versioning. 1 = basic save/load but fragile. 0 = not addressed |
-| **Schema Migration** | 0-2 | 2 = explicit migration strategy for save format changes between game versions. 1 = acknowledged but no plan. 0 = not addressed (guaranteed broken saves on update) |
-| **Cloud Sync** | 0-2 | 2 = cloud save with conflict resolution strategy documented. 1 = cloud save planned but no conflict handling. 0 = no cloud save for a game that needs it (mobile/cross-platform) |
-| **Data Integrity** | 0-2 | 2 = checksums/validation on save data, graceful handling of corrupted saves. 1 = basic validation. 0 = no corruption protection |
-| **Analytics Pipeline** | 0-1 | 1 = game telemetry events defined, pipeline documented. 0 = no analytics plan (acceptable for offline/hobby projects) |
-
-**Section 4 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 4. Five criteria: Save System Design (0-3), Schema Migration (0-2), Cloud Sync (0-2), Data Integrity (0-2), Analytics Pipeline (0-1). Total: ___/10.
 
 ### Data Red Flags
 
@@ -422,17 +353,9 @@ First, classify the networking model:
 
 ## Section 5: Asset Pipeline (素材管線) — Weight: 10%
 
-### Evaluation Criteria
+Check build sizes against store limits in `references/performance-budgets.md`. Check texture sizes and memory allocation against platform budgets.
 
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Build Size Budget** | 0-2 | 2 = per-platform size budget with current measurement. 1 = general target but not measured. 0 = no size awareness |
-| **Loading Strategy** | 0-3 | 3 = loading screens budgeted, streaming for large worlds, async loading for seamless transitions. 2 = loading exists but not optimized. 1 = synchronous loading causing hitches. 0 = not addressed |
-| **Asset Specifications** | 0-2 | 2 = texture sizes, poly budgets, audio formats standardized per platform tier. 1 = some standards but incomplete. 0 = no asset specs — artists guessing |
-| **Memory Management** | 0-2 | 2 = asset memory budget per scene/level, unloading strategy documented. 1 = general awareness but no budget. 0 = load everything, unload nothing |
-| **Platform Variants** | 0-1 | 1 = asset quality tiers for different hardware (HD/SD textures, LOD meshes). 0 = same assets for all platforms |
-
-**Section 5 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 5. Five criteria: Build Size Budget (0-2), Loading Strategy (0-3), Asset Specifications (0-2), Memory Management (0-2), Platform Variants (0-1). Total: ___/10.
 
 ### Asset Pipeline Red Flags
 
@@ -459,17 +382,7 @@ First, classify the networking model:
 
 ## Section 6: Platform Adaptation (平台適配) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Input Method Coverage** | 0-3 | 3 = all target input methods designed and tested (keyboard/mouse, controller, touch, motion). 2 = primary input method done, secondary planned. 1 = only one input method considered. 0 = input not addressed |
-| **Resolution Scaling** | 0-2 | 2 = dynamic resolution or fixed resolution targets per platform with UI scaling. 1 = single resolution with basic scaling. 0 = hardcoded resolution |
-| **Performance Tiers** | 0-2 | 2 = quality settings with clear low/medium/high definitions and auto-detection. 1 = some settings but no auto-detection. 0 = one-size-fits-all |
-| **Certification Requirements** | 0-2 | 2 = platform cert requirements documented and addressed (console TRC/XR, App Store guidelines). 1 = aware of cert but not fully addressed. 0 = not considered (will cause submission rejection) |
-| **Accessibility Baseline** | 0-1 | 1 = remappable controls, subtitle options, colorblind support planned. 0 = no accessibility considerations |
-
-**Section 6 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 6. Five criteria: Input Method Coverage (0-3), Resolution Scaling (0-2), Performance Tiers (0-2), Certification Requirements (0-2), Accessibility Baseline (0-1). Total: ___/10.
 
 ### Action Classification
 
@@ -483,17 +396,7 @@ First, classify the networking model:
 
 ## Section 7: Testing Strategy (測試策略) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Unit Test Coverage** | 0-2 | 2 = gameplay logic has unit tests, engine systems have unit tests, CI runs them. 1 = some tests exist but not systematic. 0 = no unit tests |
-| **Integration Testing** | 0-2 | 2 = system integration tests (save/load round-trip, network message flow, scene transitions). 1 = manual integration testing only. 0 = not addressed |
-| **Performance Testing** | 0-2 | 2 = automated performance benchmarks with regression detection. 1 = manual profiling occasionally. 0 = no performance testing |
-| **CI/CD Pipeline** | 0-2 | 2 = automated build, test, deploy pipeline per platform. 1 = partial automation. 0 = manual builds |
-| **Playtest Infrastructure** | 0-2 | 2 = build distribution to testers, crash reporting, analytics dashboard. 1 = ad-hoc testing distribution. 0 = no tester pipeline |
-
-**Section 7 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 7. Five criteria: Unit Test Coverage (0-2), Integration Testing (0-2), Performance Testing (0-2), CI/CD Pipeline (0-2), Playtest Infrastructure (0-2). Total: ___/10.
 
 ### Testing Red Flags
 
@@ -529,15 +432,7 @@ This section cross-validates findings across Sections 1-7 and against the GDD (i
 | **Testing × Scale** | Does test infrastructure match project complexity? | 100+ systems with no unit tests and manual-only testing |
 | **Performance × GDD** | Does frame budget support the game's vision? | GDD promises 200 units on screen but frame budget only supports 50 |
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Architecture-Design Alignment** | 0-4 | Start at 4. Deduct 1 for each cross-section contradiction found (max -4) |
-| **Platform Coherence** | 0-3 | 3 = all architectural decisions consistently support all target platforms. 2 = minor gaps. 1 = significant platform-specific gaps. 0 = architecture designed for one platform, others are afterthoughts |
-| **Technical Debt Awareness** | 0-3 | 3 = known tech debt documented with payoff plan. 2 = tech debt acknowledged. 1 = some debt visible but unacknowledged. 0 = no awareness of accumulated shortcuts |
-
-**Section 8 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 8. Three criteria: Architecture-Design Alignment (0-4), Platform Coherence (0-3), Technical Debt Awareness (0-3). Total: ___/10.
 
 ### Action Classification
 
@@ -553,33 +448,13 @@ This section cross-validates findings across Sections 1-7 and against the GDD (i
 
 ### Architecture Health Score
 
-Calculate after all sections are reviewed:
+Calculate after all sections are reviewed. Use mode-adjusted weights from `references/scoring.md` (Mode Weight Adjustments table) — do NOT use default weights blindly.
 
+Use the weighted total formula and score interpretation table from `references/scoring.md`.
+
+Include the top 3 deductions (biggest point losses) with specific reasons:
 ```
-Architecture Health Score
-═══════════════════════════════════════════════
-  Section 1 — Engine & Framework:       _/10  (weight: 15%)  → weighted: _.___
-  Section 2 — Rendering & Performance:  _/10  (weight: 20%)  → weighted: _.___
-  Section 3 — Networking Architecture:  _/10  (weight: 15%)  → weighted: _.___
-  Section 4 — Data & Persistence:       _/10  (weight: 10%)  → weighted: _.___
-  Section 5 — Asset Pipeline:           _/10  (weight: 10%)  → weighted: _.___
-  Section 6 — Platform Adaptation:      _/10  (weight: 10%)  → weighted: _.___
-  Section 7 — Testing Strategy:         _/10  (weight: 10%)  → weighted: _.___
-  Section 8 — Cross-Consistency:        _/10  (weight: 10%)  → weighted: _.___
-  ─────────────────────────────────────────────
-  WEIGHTED TOTAL:                       _._/10
-
-  * If Section 3 is N/A (single-player), redistribute 15% weight:
-    Rendering +5%, Data +5%, Testing +5%
-
-Score Interpretation:
-  8.0-10.0  PRODUCTION-READY — Architecture supports the game design, well-documented
-  6.0-7.9   SOLID — Good foundation, address flagged issues before scaling team
-  4.0-5.9   NEEDS WORK — Significant gaps that will cause production bottlenecks
-  2.0-3.9   MAJOR REVISION — Architectural decisions need rethinking
-  0.0-1.9   START OVER — No architecture yet, just technology choices
-
-Top 3 Deductions (biggest point losses):
+Top 3 Deductions:
   1. [Section] [Criterion]: -N because [specific reason]
   2. [Section] [Criterion]: -N because [specific reason]
   3. [Section] [Criterion]: -N because [specific reason]

--- a/skills/game-eng-review/SKILL.md.tmpl
+++ b/skills/game-eng-review/SKILL.md.tmpl
@@ -48,25 +48,15 @@ Review a game's technical architecture interactively. Work through each section 
 
 This skill reviews architecture DECISIONS, not code. For code review, use `/gameplay-implementation-review`.
 
-## Anti-Sycophancy Protocol
+## Load References
 
-**FORBIDDEN PHRASES — never use these or any paraphrase:**
-- "Great architecture!"
-- "This is a solid technical foundation"
-- "Good engine choice"
-- "The networking looks robust"
-- "Smart approach to optimization"
-- "This should scale well"
-- "Interesting technical decision"
+Read these reference files before starting the review — they contain scoring rubrics, platform benchmarks, and Claude-specific gotchas:
 
-**CALIBRATED ACKNOWLEDGMENT — use this instead:**
-- Name the specific technical decision and WHY it works for THIS game: "Using ECS for entity management supports the stated 200-unit battle scenes because component iteration is cache-friendly — this is the right data model for that specific scale."
-- If something is genuinely well-architected, describe the mechanical reason it works for the game's specific requirements, never just say it's "good" or "solid."
+- `references/scoring.md` — All 8 section rubrics with mode weight adjustments and scoring notes
+- `references/gotchas.md` — Claude-specific architecture review mistakes, anti-sycophancy protocol, forcing question routing
+- `references/performance-budgets.md` — Frame budgets, draw call limits, memory ceilings, texture sizes, build size limits by platform
 
-**PUSH-BACK CADENCE:**
-1. Push once: State the concern directly with evidence.
-2. Push again: If the response is vague ("we'll optimize later"), ask for the specific benchmark target, profiling plan, and fallback if targets are missed.
-3. Escalate: If still vague after two pushes, flag as ESCALATE — "This needs a concrete performance budget before architecture can be validated."
+> **Anti-sycophancy and push-back cadence:** See `references/gotchas.md`. Follow the forbidden phrases list and push-back cadence for EVERY interaction.
 
 ---
 
@@ -136,17 +126,7 @@ After Step 0 context is established, present the routing via AskUserQuestion:
 
 ## Section 1: Engine & Framework (引擎選型) — Weight: 15%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Fitness for Genre** | 0-3 | 3 = engine's strengths align with game's core requirements (e.g., Unity for mobile 2D, Unreal for high-fidelity 3D). 2 = workable but not optimal. 1 = significant workarounds needed. 0 = engine fundamentally mismatched |
-| **Team Familiarity** | 0-2 | 2 = team has shipped with this engine. 1 = team has prototyped but not shipped. 0 = team has no experience with this engine |
-| **Platform Support** | 0-2 | 2 = engine natively supports all target platforms with proven track record. 1 = supports with known limitations. 0 = requires custom porting work |
-| **Ecosystem & Tooling** | 0-1 | 1 = mature plugin ecosystem, asset store, debugging tools available. 0 = limited ecosystem or team building custom tooling for basics |
-| **License & Cost Risk** | 0-2 | 2 = licensing terms clear, sustainable at projected scale, no revenue share surprises. 1 = some cost risk at scale. 0 = license terms could become prohibitive or are unclear |
-
-**Section 1 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 1. Five criteria: Fitness for Genre (0-3), Team Familiarity (0-2), Platform Support (0-2), Ecosystem & Tooling (0-1), License & Cost Risk (0-2). Total: ___/10.
 
 ### Engine Red Flags
 
@@ -185,36 +165,9 @@ Push until you hear: A named limitation AND a concrete plan. Every engine has we
 
 ## Section 2: Rendering & Performance (渲染與效能) — Weight: 20%
 
-### Frame Budget Model
+Every game has a frame budget. Check the architecture doc against platform-specific targets in `references/performance-budgets.md` (frame budgets, draw call limits, memory ceilings). If the architecture doc does not include a frame budget: **-2 points.** Without a budget, performance is being managed by hope.
 
-Every game has a frame budget. Calculate it explicitly:
-
-```
-Target: 60 FPS → 16.67ms per frame
-Target: 30 FPS → 33.33ms per frame
-
-Budget allocation (typical):
-  Game logic:     3-5ms   (20-30%)
-  Physics:        2-4ms   (12-24%)
-  Rendering:      6-10ms  (36-60%)
-  Audio:          1-2ms   (6-12%)
-  UI:             1-2ms   (6-12%)
-  Headroom:       1-2ms   (buffer for spikes)
-```
-
-If the architecture doc does not include a frame budget: **-2 points.** Without a budget, performance is being managed by hope.
-
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Frame Budget Defined** | 0-2 | 2 = explicit ms budget per system with target FPS. 1 = target FPS stated but no per-system breakdown. 0 = no performance target |
-| **Draw Call Strategy** | 0-2 | 2 = batching/instancing strategy documented, draw call target for worst-case scene. 1 = general awareness but no target. 0 = not addressed |
-| **LOD / Culling** | 0-2 | 2 = LOD strategy with distance thresholds, frustum/occlusion culling plan. 1 = LOD mentioned but no specifics. 0 = not addressed (acceptable for 2D games — score N/A) |
-| **Shader Complexity** | 0-2 | 2 = shader budget per material tier, fallback shaders for low-end. 1 = custom shaders exist but no complexity budget. 0 = no shader strategy |
-| **Memory Budget** | 0-2 | 2 = per-platform memory ceiling with allocation breakdown (textures, meshes, audio, runtime). 1 = total memory target but no breakdown. 0 = no memory planning |
-
-**Section 2 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 2. Five criteria: Frame Budget Defined (0-2), Draw Call Strategy (0-2), LOD/Culling (0-2), Shader Complexity (0-2), Memory Budget (0-2). Total: ___/10.
 
 ### Performance Red Flags
 
@@ -253,9 +206,7 @@ Push until you hear: A graceful degradation strategy. Dynamic resolution? Partic
 
 ## Section 3: Networking Architecture (網路架構) — Weight: 15%
 
-**Skip this section if the game is single-player only.** Score as N/A and redistribute weight.
-
-### Network Model Classification
+**Skip this section if the game is single-player only.** Score as N/A and redistribute weight per mode table in `references/scoring.md`.
 
 First, classify the networking model:
 
@@ -267,17 +218,7 @@ First, classify the networking model:
 | **Turn-Based** | High (async OK) | Low | Low | Hearthstone, chess |
 | **Async/Social** | Very High | Very Low | Low | Clash of Clans attacks, leaderboards |
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Model Fitness** | 0-3 | 3 = network model matches game's latency/bandwidth needs. 2 = workable but suboptimal. 1 = will cause noticeable player-facing issues. 0 = model cannot support core gameplay |
-| **State Synchronization** | 0-2 | 2 = sync strategy documented (what state is authoritative, what is predicted, what is cosmetic). 1 = general sync approach but no state classification. 0 = not addressed |
-| **Latency Handling** | 0-2 | 2 = prediction/rollback/interpolation strategy documented with target latency tolerance. 1 = acknowledged but no specific strategy. 0 = not addressed (for action games, this is -2 effectively) |
-| **Cheat Prevention** | 0-2 | 2 = server-authoritative for game-critical state, client validation documented. 1 = some server authority but gaps identified. 0 = trust-the-client architecture for competitive game |
-| **Failure Modes** | 0-1 | 1 = disconnect handling, reconnect flow, and desync recovery documented. 0 = not addressed |
-
-**Section 3 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 3. Five criteria: Model Fitness (0-3), State Synchronization (0-2), Latency Handling (0-2), Cheat Prevention (0-2), Failure Modes (0-1). Total: ___/10.
 
 ### Networking Red Flags
 
@@ -305,17 +246,7 @@ First, classify the networking model:
 
 ## Section 4: Data & Persistence (資料與存檔) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Save System Design** | 0-3 | 3 = save format documented, versioned, tested for corruption recovery. 2 = save system exists but no versioning. 1 = basic save/load but fragile. 0 = not addressed |
-| **Schema Migration** | 0-2 | 2 = explicit migration strategy for save format changes between game versions. 1 = acknowledged but no plan. 0 = not addressed (guaranteed broken saves on update) |
-| **Cloud Sync** | 0-2 | 2 = cloud save with conflict resolution strategy documented. 1 = cloud save planned but no conflict handling. 0 = no cloud save for a game that needs it (mobile/cross-platform) |
-| **Data Integrity** | 0-2 | 2 = checksums/validation on save data, graceful handling of corrupted saves. 1 = basic validation. 0 = no corruption protection |
-| **Analytics Pipeline** | 0-1 | 1 = game telemetry events defined, pipeline documented. 0 = no analytics plan (acceptable for offline/hobby projects) |
-
-**Section 4 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 4. Five criteria: Save System Design (0-3), Schema Migration (0-2), Cloud Sync (0-2), Data Integrity (0-2), Analytics Pipeline (0-1). Total: ___/10.
 
 ### Data Red Flags
 
@@ -343,17 +274,9 @@ First, classify the networking model:
 
 ## Section 5: Asset Pipeline (素材管線) — Weight: 10%
 
-### Evaluation Criteria
+Check build sizes against store limits in `references/performance-budgets.md`. Check texture sizes and memory allocation against platform budgets.
 
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Build Size Budget** | 0-2 | 2 = per-platform size budget with current measurement. 1 = general target but not measured. 0 = no size awareness |
-| **Loading Strategy** | 0-3 | 3 = loading screens budgeted, streaming for large worlds, async loading for seamless transitions. 2 = loading exists but not optimized. 1 = synchronous loading causing hitches. 0 = not addressed |
-| **Asset Specifications** | 0-2 | 2 = texture sizes, poly budgets, audio formats standardized per platform tier. 1 = some standards but incomplete. 0 = no asset specs — artists guessing |
-| **Memory Management** | 0-2 | 2 = asset memory budget per scene/level, unloading strategy documented. 1 = general awareness but no budget. 0 = load everything, unload nothing |
-| **Platform Variants** | 0-1 | 1 = asset quality tiers for different hardware (HD/SD textures, LOD meshes). 0 = same assets for all platforms |
-
-**Section 5 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 5. Five criteria: Build Size Budget (0-2), Loading Strategy (0-3), Asset Specifications (0-2), Memory Management (0-2), Platform Variants (0-1). Total: ___/10.
 
 ### Asset Pipeline Red Flags
 
@@ -380,17 +303,7 @@ First, classify the networking model:
 
 ## Section 6: Platform Adaptation (平台適配) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Input Method Coverage** | 0-3 | 3 = all target input methods designed and tested (keyboard/mouse, controller, touch, motion). 2 = primary input method done, secondary planned. 1 = only one input method considered. 0 = input not addressed |
-| **Resolution Scaling** | 0-2 | 2 = dynamic resolution or fixed resolution targets per platform with UI scaling. 1 = single resolution with basic scaling. 0 = hardcoded resolution |
-| **Performance Tiers** | 0-2 | 2 = quality settings with clear low/medium/high definitions and auto-detection. 1 = some settings but no auto-detection. 0 = one-size-fits-all |
-| **Certification Requirements** | 0-2 | 2 = platform cert requirements documented and addressed (console TRC/XR, App Store guidelines). 1 = aware of cert but not fully addressed. 0 = not considered (will cause submission rejection) |
-| **Accessibility Baseline** | 0-1 | 1 = remappable controls, subtitle options, colorblind support planned. 0 = no accessibility considerations |
-
-**Section 6 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 6. Five criteria: Input Method Coverage (0-3), Resolution Scaling (0-2), Performance Tiers (0-2), Certification Requirements (0-2), Accessibility Baseline (0-1). Total: ___/10.
 
 ### Action Classification
 
@@ -404,17 +317,7 @@ First, classify the networking model:
 
 ## Section 7: Testing Strategy (測試策略) — Weight: 10%
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Unit Test Coverage** | 0-2 | 2 = gameplay logic has unit tests, engine systems have unit tests, CI runs them. 1 = some tests exist but not systematic. 0 = no unit tests |
-| **Integration Testing** | 0-2 | 2 = system integration tests (save/load round-trip, network message flow, scene transitions). 1 = manual integration testing only. 0 = not addressed |
-| **Performance Testing** | 0-2 | 2 = automated performance benchmarks with regression detection. 1 = manual profiling occasionally. 0 = no performance testing |
-| **CI/CD Pipeline** | 0-2 | 2 = automated build, test, deploy pipeline per platform. 1 = partial automation. 0 = manual builds |
-| **Playtest Infrastructure** | 0-2 | 2 = build distribution to testers, crash reporting, analytics dashboard. 1 = ad-hoc testing distribution. 0 = no tester pipeline |
-
-**Section 7 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 7. Five criteria: Unit Test Coverage (0-2), Integration Testing (0-2), Performance Testing (0-2), CI/CD Pipeline (0-2), Playtest Infrastructure (0-2). Total: ___/10.
 
 ### Testing Red Flags
 
@@ -450,15 +353,7 @@ This section cross-validates findings across Sections 1-7 and against the GDD (i
 | **Testing × Scale** | Does test infrastructure match project complexity? | 100+ systems with no unit tests and manual-only testing |
 | **Performance × GDD** | Does frame budget support the game's vision? | GDD promises 200 units on screen but frame budget only supports 50 |
 
-### Evaluation Criteria
-
-| Criterion | Points | Deduction Rules |
-|-----------|--------|-----------------|
-| **Architecture-Design Alignment** | 0-4 | Start at 4. Deduct 1 for each cross-section contradiction found (max -4) |
-| **Platform Coherence** | 0-3 | 3 = all architectural decisions consistently support all target platforms. 2 = minor gaps. 1 = significant platform-specific gaps. 0 = architecture designed for one platform, others are afterthoughts |
-| **Technical Debt Awareness** | 0-3 | 3 = known tech debt documented with payoff plan. 2 = tech debt acknowledged. 1 = some debt visible but unacknowledged. 0 = no awareness of accumulated shortcuts |
-
-**Section 8 Score: ___/10**
+> **Scoring:** See `references/scoring.md`, Section 8. Three criteria: Architecture-Design Alignment (0-4), Platform Coherence (0-3), Technical Debt Awareness (0-3). Total: ___/10.
 
 ### Action Classification
 
@@ -474,33 +369,13 @@ This section cross-validates findings across Sections 1-7 and against the GDD (i
 
 ### Architecture Health Score
 
-Calculate after all sections are reviewed:
+Calculate after all sections are reviewed. Use mode-adjusted weights from `references/scoring.md` (Mode Weight Adjustments table) — do NOT use default weights blindly.
 
+Use the weighted total formula and score interpretation table from `references/scoring.md`.
+
+Include the top 3 deductions (biggest point losses) with specific reasons:
 ```
-Architecture Health Score
-═══════════════════════════════════════════════
-  Section 1 — Engine & Framework:       _/10  (weight: 15%)  → weighted: _.___
-  Section 2 — Rendering & Performance:  _/10  (weight: 20%)  → weighted: _.___
-  Section 3 — Networking Architecture:  _/10  (weight: 15%)  → weighted: _.___
-  Section 4 — Data & Persistence:       _/10  (weight: 10%)  → weighted: _.___
-  Section 5 — Asset Pipeline:           _/10  (weight: 10%)  → weighted: _.___
-  Section 6 — Platform Adaptation:      _/10  (weight: 10%)  → weighted: _.___
-  Section 7 — Testing Strategy:         _/10  (weight: 10%)  → weighted: _.___
-  Section 8 — Cross-Consistency:        _/10  (weight: 10%)  → weighted: _.___
-  ─────────────────────────────────────────────
-  WEIGHTED TOTAL:                       _._/10
-
-  * If Section 3 is N/A (single-player), redistribute 15% weight:
-    Rendering +5%, Data +5%, Testing +5%
-
-Score Interpretation:
-  8.0-10.0  PRODUCTION-READY — Architecture supports the game design, well-documented
-  6.0-7.9   SOLID — Good foundation, address flagged issues before scaling team
-  4.0-5.9   NEEDS WORK — Significant gaps that will cause production bottlenecks
-  2.0-3.9   MAJOR REVISION — Architectural decisions need rethinking
-  0.0-1.9   START OVER — No architecture yet, just technology choices
-
-Top 3 Deductions (biggest point losses):
+Top 3 Deductions:
   1. [Section] [Criterion]: -N because [specific reason]
   2. [Section] [Criterion]: -N because [specific reason]
   3. [Section] [Criterion]: -N because [specific reason]

--- a/skills/game-eng-review/references/gotchas.md
+++ b/skills/game-eng-review/references/gotchas.md
@@ -1,8 +1,31 @@
-# game-eng-review — Gotchas & Anti-Sycophancy
+# Anti-Sycophancy Protocol & Claude-Specific Gotchas
+
+## Claude-Specific Gotchas for Architecture Review
+
+These are mistakes Claude specifically makes when reviewing game technical architecture:
+
+1. **Accepts architecture diagrams at face value.** Claude sees a clean box-and-arrow diagram and says "well-structured" without checking if the described connections actually exist in the codebase or if the boxes represent real, implemented systems. Push: "Is this diagram describing the current architecture or the aspirational one? When was it last updated?"
+
+2. **Conflates engine popularity with fitness.** Claude defaults to "Unity is a good choice" because it is common in training data, not because it fits THIS game's specific requirements. A popular engine can be a terrible fit. Push: "What does this engine do better than alternatives for THIS game's specific mechanics?"
+
+3. **Treats deferred optimization as a valid plan.** Claude accepts "we will optimize later" when the architecture IS the optimization. Frame budget, memory budget, and draw call targets are architectural decisions. If they are not set now, they will be discovered as crises, not addressed as plans. Flag every instance of deferred optimization as a red flag.
+
+4. **Skips the multiplication.** Claude reviews each system's memory budget in isolation — textures look fine, audio looks fine, runtime objects look fine — but does not total them to check if they exceed device RAM. Always sum all subsystem budgets against the platform ceiling. See `references/performance-budgets.md` for platform memory limits.
+
+5. **Defaults to desktop assumptions.** Claude's training data is desktop-heavy. Mobile constraints (thermal throttling reducing sustained GPU to 60-70% of peak, battery drain from sustained computation, 2GB RAM devices still in active use, 100-300 draw call ceilings) are systematically underweighted. When reviewing a mobile game, actively apply mobile constraints from `references/performance-budgets.md` before evaluating.
+
+6. **Trusts stated performance targets.** If the architecture doc says "targeting 60fps", Claude takes it as achieved or achievable without evidence. Push for profiling data, benchmark results, or at minimum a frame budget breakdown that shows the math works. "Targeting 60fps" without a frame budget is a wish, not a plan.
+
+7. **Ignores build pipeline as architecture.** CI/CD, asset import pipeline, and build configuration ARE architecture — they determine how fast the team can iterate, how reliably they can ship, and what platforms they can actually target. Claude tends to treat these as devops afterthoughts. Review them with the same rigor as rendering or networking.
+
+8. **Anchoring to Section 1.** If the engine choice scores well, Claude becomes lenient in subsequent sections. Each section is scored independently against its own rubric. A perfect engine choice does not excuse a missing frame budget.
+
+9. **Conflates documentation quality with architecture quality.** A well-written architecture doc can describe a terrible architecture. A terse architecture doc can describe a good one. Score the DECISIONS, not the prose. If the doc reads well but the decisions do not hold up to scrutiny, the score should be low.
 
 ## Anti-Sycophancy Protocol
 
-**FORBIDDEN PHRASES — never use these or any paraphrase:**
+### Forbidden Phrases — never use these or any paraphrase
+
 - "Great architecture!"
 - "This is a solid technical foundation"
 - "Good engine choice"
@@ -11,14 +34,28 @@
 - "This should scale well"
 - "Interesting technical decision"
 
-**CALIBRATED ACKNOWLEDGMENT — use this instead:**
+### Calibrated Acknowledgment — use this instead
+
 - Name the specific technical decision and WHY it works for THIS game: "Using ECS for entity management supports the stated 200-unit battle scenes because component iteration is cache-friendly — this is the right data model for that specific scale."
-- If something is genuinely well-architected, describe the mechanical reason it works for the game's specific requirements, never just say it's "good" or "solid."
+- If something is genuinely well-architected, describe the mechanical reason it works for the game's specific requirements. Never just say it is "good" or "solid."
 
-**PUSH-BACK CADENCE:**
-1. Push once: State the concern directly with evidence.
-2. Push again: If the response is vague ("we'll optimize later"), ask for the specific benchmark target, profiling plan, and fallback if targets are missed.
-3. Escalate: If still vague after two pushes, flag as ESCALATE — "This needs a concrete performance budget before architecture can be validated."
+### Push-Back Cadence
 
----
+1. **Push once:** State the concern directly with evidence.
+2. **Push again:** If the response is vague ("we will optimize later"), ask for the specific benchmark target, profiling plan, and fallback if targets are missed.
+3. **Escalate:** If still vague after two pushes, flag as ESCALATE — "This needs a concrete performance budget before architecture can be validated."
 
+## Forcing Question Routing
+
+Use this table to prioritize which forcing questions to ask based on game type and stage:
+
+| Game Type | Stage | Priority Forcing Questions |
+|-----------|-------|---------------------------|
+| Single-player PC/Console | Early | S1-Q1 (engine fitness), S2-Q1 (worst-case scene), S4-Q1 (save migration) |
+| Single-player PC/Console | Near Ship | S5-Q1 (build size), S7 (CI/CD status), S2-Q2 (degradation strategy) |
+| Mobile F2P | Early | S1-Q1 (engine fitness), S2-Q1 (worst-case scene), S5-Q1 (build size) |
+| Mobile F2P | Near Ship | S6 (cert requirements), S5-Q2 (loading strategy), S2-Q2 (thermal throttle) |
+| Multiplayer Action | Early | S3-Q1 (300ms ping experience), S3-Q2 (state boundary), S1-Q2 (engine limitation) |
+| Multiplayer Action | Near Ship | S3-Q3 (bandwidth budget), S7 (load testing), S8 (cross-validation) |
+| Multiplayer Casual | Early | S3-Q2 (state boundary), S1-Q1 (engine fitness), S4-Q2 (cloud sync) |
+| Prototype | Any | S1-Q1 (engine fitness), S1-Q2 (engine limitation), S8 (coherence check) |

--- a/skills/game-eng-review/references/performance-budgets.md
+++ b/skills/game-eng-review/references/performance-budgets.md
@@ -1,0 +1,137 @@
+# Performance Budgets by Platform
+
+Canonical platform-level performance budgets for game architecture review.
+Other skills (e.g., `/asset-review`) should reference this file for platform constraints rather than maintaining separate copies.
+
+## Frame Budget by Platform
+
+| Platform | Target FPS | Frame Budget | Notes |
+|----------|-----------|-------------|-------|
+| PC (high-end) | 60-144 | 6.9-16.67ms | Variable refresh (G-Sync/FreeSync) provides headroom |
+| PC (min spec) | 30-60 | 16.67-33.33ms | Define min spec explicitly — "most PCs" is not a spec |
+| PS5 / Xbox Series X | 60 (or 30 quality) | 16.67ms (or 33.33ms) | Players expect 60fps mode; 30fps needs visual justification |
+| PS4 / Xbox One | 30 | 33.33ms | Still a large installed base; do not ignore |
+| Nintendo Switch (docked) | 30 | 33.33ms | GPU is mobile-class; plan accordingly |
+| Nintendo Switch (handheld) | 30 | 33.33ms | Thermal throttle reduces GPU by ~20% vs docked |
+| Mobile (high-end) | 60 | 16.67ms | Sustained performance is 60-70% of peak due to thermal throttling |
+| Mobile (mid-range) | 30 | 33.33ms | Thermal throttle after 3-5 minutes of sustained load |
+| Mobile (low-end) | 30 | 33.33ms | 2GB RAM ceiling, single-core bottleneck common |
+| WebGL | 30-60 | Variable | JS overhead adds +3-5ms per frame; no threading |
+
+### Frame Budget Allocation (Typical)
+
+| System | % of Frame | 60fps (16.67ms) | 30fps (33.33ms) |
+|--------|-----------|-----------------|-----------------|
+| Rendering | 35-45% | 5.8-7.5ms | 11.7-15.0ms |
+| Game Logic | 20-25% | 3.3-4.2ms | 6.7-8.3ms |
+| Physics | 12-18% | 2.0-3.0ms | 4.0-6.0ms |
+| Audio | 5-10% | 0.8-1.7ms | 1.7-3.3ms |
+| UI | 5-10% | 0.8-1.7ms | 1.7-3.3ms |
+| Headroom (spike buffer) | 5-10% | 0.8-1.7ms | 1.7-3.3ms |
+
+**Key rule:** If subsystem budgets do not sum to less than the frame budget, the architecture is over-committed. Always check the sum.
+
+## Draw Call Budgets
+
+Draw calls are the primary rendering bottleneck on mobile and a significant factor on all platforms.
+
+| Platform | Draw Call Budget | With Instancing | Notes |
+|----------|-----------------|-----------------|-------|
+| Mobile (low-end) | 50-100 | 100-200 | GPU driver overhead dominates |
+| Mobile (mid-range) | 100-300 | 300-600 | Vulkan/Metal reduce driver overhead |
+| Mobile (high-end) | 300-500 | 500-1000 | Still far below desktop |
+| Nintendo Switch | 300-800 | 800-1500 | Depends on docked vs handheld |
+| PC (mid-range) | 2000-3000 | 5000-10000 | DirectX 12/Vulkan reduce overhead |
+| PC (high-end) | 3000-5000 | 10000+ | Rarely the bottleneck on modern GPUs |
+| PS5 / Xbox Series X | 3000-5000 | 8000+ | Custom GPU command buffers |
+| PS4 / Xbox One | 1000-2000 | 3000-5000 | Previous-gen hardware limits |
+| WebGL | 100-500 | 500-1000 | Browser overhead; WebGPU improves this |
+
+### Batching Strategies
+
+- **Static batching:** Pre-combine meshes that share material and never move. Best for environment geometry.
+- **Dynamic batching:** Runtime combine small meshes (<300 vertices per mesh). Free but limited to simple geometry.
+- **GPU instancing:** Same mesh drawn many times with different transforms. Best for repeated objects (trees, bullets, crowds).
+- **SRP batching (Unity) / Automatic instancing (Unreal):** Engine-level batching. Requires compatible shaders.
+- **Indirect rendering:** GPU-driven rendering pipeline. Complex to implement, massive draw call reduction for large scenes.
+
+**When to use which:** Static for environments, instancing for repeated objects, indirect for 1000+ unique objects. If the architecture doc mentions none of these for a game with complex scenes, flag as concern.
+
+## Memory Budgets by Platform
+
+| Platform | Total RAM | OS/System Overhead | Available for Game | Texture Budget (40-60%) |
+|----------|----------|-------------------|-------------------|------------------------|
+| Mobile (low-end, 2GB) | 2 GB | ~800 MB | ~1.0-1.2 GB | 400-700 MB |
+| Mobile (mid-range, 4GB) | 4 GB | ~1.2 GB | ~2.5-2.8 GB | 1.0-1.7 GB |
+| Mobile (high-end, 6-8GB) | 6-8 GB | ~1.5 GB | ~4.0-6.0 GB | 1.6-3.6 GB |
+| Nintendo Switch | 4 GB | ~1 GB | ~3.0 GB | 1.2-1.8 GB |
+| PS4 / Xbox One | 8 GB (unified) | ~3 GB | ~5.0 GB | 2.0-3.0 GB |
+| PS5 / Xbox Series X | 16 GB (unified) | ~4 GB | ~12.0 GB | 4.8-7.2 GB |
+| PC (min spec, 8GB) | 8 GB | ~3 GB | ~4.5-5.0 GB | 1.8-3.0 GB |
+| PC (recommended, 16GB) | 16 GB | ~4 GB | ~11.0-12.0 GB | 4.4-7.2 GB |
+| WebGL | ~1-2 GB (browser tab limit) | ~500 MB | ~500 MB-1.5 GB | 200-900 MB |
+
+### Memory Allocation Guidelines
+
+| Category | % of Game Budget | Notes |
+|----------|-----------------|-------|
+| Textures | 40-60% | Largest single consumer; compress aggressively on mobile |
+| Meshes / Geometry | 10-20% | LOD reduces this significantly for 3D games |
+| Audio | 5-15% | Compressed streaming for music; uncompressed for SFX latency |
+| Runtime Objects / Heap | 10-20% | GC-heavy languages (C#, JS) need allocation strategy for hot paths |
+| Shaders / Materials | 3-8% | Shader variants can explode memory; audit variant count |
+| UI / Fonts / Atlases | 2-5% | Font atlases with CJK support can be surprisingly large |
+| System / Engine Overhead | 5-10% | Includes engine runtime, physics broadphase, navigation mesh |
+
+**Critical check:** Sum all subsystem budgets. If total exceeds "Available for Game" for the target platform's minimum spec, the architecture is over-committed. This is the "multiplication" Claude tends to skip.
+
+## Texture Size Standards
+
+These are maximum texture dimensions per asset type. Actual texture memory depends on format and compression.
+
+| Asset Type | Mobile | PC / Console | Notes |
+|-----------|--------|-------------|-------|
+| Character (hero/player) | 512-1024 | 2048-4096 | Main character often gets the largest budget |
+| Character (NPC / enemy) | 256-512 | 1024-2048 | Scale with screen importance |
+| Environment (tileset/terrain) | 256-512 | 512-2048 | Tiling textures can be smaller |
+| Props / Small objects | 128-256 | 256-1024 | Often atlas-packed |
+| UI elements | 128-256 | 256-512 | Vector UI avoids this entirely |
+| Skybox / Panorama | 1024 | 2048-4096 | Single large texture, loaded once |
+| Effects / Particles | 64-128 | 128-512 | Small and numerous; atlas-pack |
+| Lightmaps (per chunk) | 256-512 | 512-2048 | Can dominate memory if unbounded |
+
+### Compression Formats
+
+| Platform | Recommended Format | Ratio vs Uncompressed | Notes |
+|----------|-------------------|----------------------|-------|
+| iOS | ASTC (4x4 to 8x8) | 4:1 to 16:1 | Quality vs size trade-off via block size |
+| Android | ASTC or ETC2 | 4:1 to 16:1 | ETC2 for broad compat; ASTC for quality |
+| PC (DirectX) | BC7 (quality) / BC1 (size) | 4:1 to 8:1 | BC7 for color, BC5 for normals |
+| Console | BC7 / platform-native | 4:1 to 8:1 | Similar to PC |
+| WebGL | Basis Universal / KTX2 | 6:1 to 16:1 | Transcodes to platform-native at load |
+
+## Build Size Limits by Store
+
+| Store / Platform | Hard Limit | Practical Limit | Notes |
+|-----------------|-----------|----------------|-------|
+| iOS App Store | 4 GB | 200 MB (OTA) | >200 MB requires WiFi download; impacts conversion |
+| Google Play Store | 150 MB base APK | 150 MB base | Play Asset Delivery for additional content (up to 2 GB) |
+| Nintendo eShop | 32 GB | Varies by cartridge size | MicroSD consideration; digital-only games should target <8 GB |
+| PlayStation Store | 50 GB (disc) | No hard digital limit | Larger games need mandatory install management |
+| Xbox Store | 50 GB (disc) | No hard digital limit | Smart Delivery can reduce per-platform size |
+| Steam | No hard limit | <20 GB recommended | >20 GB reduces install conversion; >100 GB is a support burden |
+| itch.io | 1 GB default | Can request increase | Web builds should target <50 MB |
+| WebGL (browser) | No store limit | <50 MB ideal | >100 MB causes high abandonment; >200 MB is unusable on mobile browsers |
+
+### Size Budget Allocation (Typical)
+
+| Content Type | % of Build | Notes |
+|-------------|-----------|-------|
+| Textures (compressed) | 30-50% | Usually the largest contributor |
+| Audio (compressed) | 15-30% | Music and voice acting dominate |
+| Meshes / Geometry | 5-15% | Small for 2D games |
+| Code / Scripts | 2-10% | Larger for scripted engines (Unity IL2CPP, Godot) |
+| Video / Cutscenes | 0-30% | Can dominate if present; consider streaming |
+| Shaders (compiled) | 1-5% | Variant explosion can inflate this |
+| Level Data / Configs | 2-8% | Includes scene files, prefabs, configs |
+| Engine Runtime | 5-15% | Overhead varies dramatically by engine |

--- a/skills/game-eng-review/references/scoring.md
+++ b/skills/game-eng-review/references/scoring.md
@@ -1,12 +1,34 @@
-# game-eng-review — Scoring Rubrics
+# Scoring Rubrics & Mode Weights
 
-## Section 1: Engine & Framework (引擎選型) — Weight: 15%
+## Mode Weight Adjustments
 
-### Evaluation Criteria
+Default weights assume a multi-platform PC/console game. Adjust per game type:
+
+| Section | Default | A: Single-player PC | B: Mobile F2P | C: Multiplayer Action | D: Multiplayer Casual | E: Prototype |
+|---------|---------|---------------------|---------------|----------------------|----------------------|-------------|
+| 1. Engine & Framework | 15% | 15% | 15% | 10% | 10% | 25% |
+| 2. Rendering & Performance | 20% | 25% | 25% | 20% | 15% | 20% |
+| 3. Networking Architecture | 15% | SKIP | SKIP | 25% | 20% | SKIP |
+| 4. Data & Persistence | 10% | 15% | 15% | 10% | 10% | 5% |
+| 5. Asset Pipeline | 10% | 10% | 15% | 10% | 10% | 5% |
+| 6. Platform Adaptation | 10% | 10% | 15% | 10% | 15% | 5% |
+| 7. Testing Strategy | 10% | 15% | 10% | 10% | 10% | 5% |
+| 8. Cross-Section Consistency | 10% | 10% | 5% | 5% | 10% | 35% |
+
+**Weight rationale:**
+- **Single-player PC:** No networking. Rendering and testing get extra weight because single-player games have no "server-side fix" for shipped bugs. Data gets more weight because save corruption is unrecoverable without cloud.
+- **Mobile F2P:** Rendering and asset pipeline are critical due to hardware diversity and store size limits. Platform adaptation matters more (iOS/Android differences, thermal throttling). Cross-consistency matters less because iterative live-ops allows course correction.
+- **Multiplayer Action:** Networking jumps to 25% — it IS the architecture for action multiplayer. Engine drops because the networking model constrains engine choice, not vice versa.
+- **Multiplayer Casual:** Networking important but less latency-sensitive. Platform adaptation high because casual games target the widest hardware range.
+- **Prototype:** Engine choice and cross-consistency dominate. Everything else is structural check only — premature optimization of rendering or networking wastes prototype velocity.
+
+When Section 3 (Networking) is SKIP, redistribute its weight as noted in each column above.
+
+## Section 1: Engine & Framework — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
-| **Fitness for Genre** | 0-3 | 3 = engine's strengths align with game's core requirements (e.g., Unity for mobile 2D, Unreal for high-fidelity 3D). 2 = workable but not optimal. 1 = significant workarounds needed. 0 = engine fundamentally mismatched |
+| **Fitness for Genre** | 0-3 | 3 = engine strengths align with core requirements (e.g., Unity for mobile 2D, Unreal for high-fidelity 3D). 2 = workable but not optimal. 1 = significant workarounds needed. 0 = engine fundamentally mismatched |
 | **Team Familiarity** | 0-2 | 2 = team has shipped with this engine. 1 = team has prototyped but not shipped. 0 = team has no experience with this engine |
 | **Platform Support** | 0-2 | 2 = engine natively supports all target platforms with proven track record. 1 = supports with known limitations. 0 = requires custom porting work |
 | **Ecosystem & Tooling** | 0-1 | 1 = mature plugin ecosystem, asset store, debugging tools available. 0 = limited ecosystem or team building custom tooling for basics |
@@ -14,24 +36,13 @@
 
 **Section 1 Score: ___/10**
 
-### Engine Red Flags
+### Scoring Notes
 
-- Custom engine for a small team with a deadline — almost always wrong unless the team has shipped a custom engine before
-- Engine version locked to an old release with no upgrade plan — accumulating tech debt
-- "We chose it because we like it" with no analysis of game requirements fit
-- Engine requires workarounds for a core game mechanic (e.g., tile-based game on an engine with no native tilemap)
-- No build pipeline established yet — "we'll figure out builds later"
+- **Fitness for Genre** is the highest-weight criterion because a mismatched engine creates cascading problems in every other section.
+- **Team Familiarity** score of 0 is not automatically fatal — a team learning a well-fitted engine may be better off than a team using a familiar but mismatched one. Weight this against Fitness.
+- **License & Cost Risk:** Score 0 only when licensing is genuinely unclear or hostile (not when the team simply has not read the terms — that is an ASK, not a deduction).
 
-### Forcing Questions
-
-Ask via AskUserQuestion, **ONE AT A TIME:**
-
-**Q1:** "What is the ONE thing this engine does better than alternatives for YOUR specific game?"
-
---
-If the architecture doc does not include a frame budget: **-2 points.** Without a budget, performance is being managed by hope.
-
-### Evaluation Criteria
+## Section 2: Rendering & Performance — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -43,53 +54,31 @@ If the architecture doc does not include a frame budget: **-2 points.** Without 
 
 **Section 2 Score: ___/10**
 
-### Performance Red Flags
+### Scoring Notes
 
-- "We'll optimize later" — optimization is architectural, not a polish task
-- No profiling infrastructure in the project — if you can't measure, you can't manage
-- Texture sizes not standardized — a single 4K texture can blow mobile memory
-- No target hardware defined — "it should run on most PCs" is not a spec
-- GC-heavy language (C#, JS) with no allocation strategy for hot paths
+- If the architecture doc does not include a frame budget: **-2 points** from Frame Budget Defined. Without a budget, performance is managed by hope.
+- For 2D games, LOD/Culling should be scored N/A and its 2 points redistributed equally to Frame Budget and Memory Budget.
+- **Draw Call Strategy** at score 0 is more severe on mobile (where draw calls are the primary bottleneck) than on modern PC/console. See `references/performance-budgets.md` for platform-specific targets.
 
-### Forcing Questions
-
-Ask via AskUserQuestion, **ONE AT A TIME:**
-
-**Q1:** "What is your worst-case scene in terms of rendering cost, and have you profiled it?"
-
---
-| **Async/Social** | Very High | Very Low | Low | Clash of Clans attacks, leaderboards |
-
-### Evaluation Criteria
+## Section 3: Networking Architecture — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
-| **Model Fitness** | 0-3 | 3 = network model matches game's latency/bandwidth needs. 2 = workable but suboptimal. 1 = will cause noticeable player-facing issues. 0 = model cannot support core gameplay |
+| **Model Fitness** | 0-3 | 3 = network model matches latency/bandwidth needs. 2 = workable but suboptimal. 1 = will cause noticeable player-facing issues. 0 = model cannot support core gameplay |
 | **State Synchronization** | 0-2 | 2 = sync strategy documented (what state is authoritative, what is predicted, what is cosmetic). 1 = general sync approach but no state classification. 0 = not addressed |
-| **Latency Handling** | 0-2 | 2 = prediction/rollback/interpolation strategy documented with target latency tolerance. 1 = acknowledged but no specific strategy. 0 = not addressed (for action games, this is -2 effectively) |
+| **Latency Handling** | 0-2 | 2 = prediction/rollback/interpolation strategy documented with target latency tolerance. 1 = acknowledged but no specific strategy. 0 = not addressed (for action games, this is effectively -2) |
 | **Cheat Prevention** | 0-2 | 2 = server-authoritative for game-critical state, client validation documented. 1 = some server authority but gaps identified. 0 = trust-the-client architecture for competitive game |
 | **Failure Modes** | 0-1 | 1 = disconnect handling, reconnect flow, and desync recovery documented. 0 = not addressed |
 
 **Section 3 Score: ___/10**
 
-### Networking Red Flags
+### Scoring Notes
 
-- Client-authoritative for competitive multiplayer — cheating will be trivial
-- No tick rate specified — "as fast as possible" is not a design
-- Rollback/prediction not planned for action games with <200ms latency requirement
-- No bandwidth budget — streaming too much state will cause lag on mobile networks
-- "We'll add multiplayer later" to a game designed around multiplayer — networking is foundational, not a feature
+- **Model Fitness** at 3 points is the gateway criterion. If the network model is wrong, nothing else in this section matters.
+- **Latency Handling** score 0 for an action game (tick rate > 10Hz) should be an automatic ESCALATE — this is not a deferred item.
+- For async/social networking (leaderboards, ghost data), scoring should be lenient on Latency Handling and Cheat Prevention but strict on State Synchronization.
 
-### Forcing Questions (must ask at least 2)
-
-1. "What happens when a player has 300ms ping? Describe their exact experience." — Tests whether latency handling is designed or hoped for.
-2. "Which game state lives on the server and which on the client? Can you draw the boundary?" — If this boundary is unclear, cheat prevention and desync bugs will be constant.
-3. "What is the maximum bandwidth per player per second, and does it fit within mobile data constraints?" — Mobile networks have real bandwidth limits (~50-100 KB/s practical for games).
-
---
-## Section 4: Data & Persistence (資料與存檔) — Weight: 10%
-
-### Evaluation Criteria
+## Section 4: Data & Persistence — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -101,24 +90,13 @@ Ask via AskUserQuestion, **ONE AT A TIME:**
 
 **Section 4 Score: ___/10**
 
-### Data Red Flags
+### Scoring Notes
 
-- Save file is a raw serialized object dump — any class change breaks saves
-- No save versioning — first patch will corrupt existing player saves
-- Cloud sync with no conflict resolution — "last write wins" loses player progress
-- Player-facing data stored in plain text with no validation — trivial to cheat, easy to corrupt
-- No analytics events for key game moments — can't measure retention without data
+- **Schema Migration** score 0 for a game planning post-launch updates should be an ESCALATE. First patch WILL break saves.
+- **Cloud Sync** score 0 is acceptable for single-platform offline games. Do not deduct for a PC-only single-player game without cloud save — it is a nice-to-have, not architecture.
+- **Analytics Pipeline** score 0 is acceptable for hobby/jam projects. For commercial F2P, score 0 here should trigger an ASK.
 
-### Forcing Questions (must ask at least 2)
-
-1. "A player updates the game and loads their old save. What happens if you added a new stat since their last play?" — Tests schema migration. If the answer is "it crashes" or "we haven't thought about it," saves will break.
-2. "A player plays on their phone, then opens the game on their tablet. Both have different progress. What happens?" — Tests cloud sync conflict resolution.
-3. "How large is a typical save file, and how long does saving take?" — Large saves cause hitches. Frequent autosaves with large files = frame drops.
-
---
-## Section 5: Asset Pipeline (素材管線) — Weight: 10%
-
-### Evaluation Criteria
+## Section 5: Asset Pipeline — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -130,24 +108,13 @@ Ask via AskUserQuestion, **ONE AT A TIME:**
 
 **Section 5 Score: ___/10**
 
-### Asset Pipeline Red Flags
+### Scoring Notes
 
-- No texture size standards — artists delivering 4K textures for mobile game
-- Build size exceeds store limits (iOS: 200MB OTA, Google Play: 150MB base APK)
-- All assets loaded at launch — long initial load, high memory usage
-- No asset import pipeline automation — manual export/import prone to errors
-- Audio files uncompressed in build — massive size increase for minimal quality gain
+- **Build Size Budget** is critical for mobile (store limits are hard walls). See `references/performance-budgets.md` for platform-specific limits.
+- **Loading Strategy** score 1 (synchronous loading) is a red flag for any game with scene transitions — players perceive freezes as crashes.
+- **Asset Specifications** score 0 is the single most common source of bloated builds. Artists without specs will deliver quality appropriate to their monitor, not the target device.
 
-### Forcing Questions (must ask at least 2)
-
-1. "What is your current build size per platform, and what is the limit?" — If they don't know, they haven't checked. Store limits are hard walls.
-2. "What happens when a player enters a new area — is loading synchronous or streamed?" — Synchronous loading = freeze. Long freezes = player thinks game crashed.
-
-### Action Classification
---
-## Section 6: Platform Adaptation (平台適配) — Weight: 10%
-
-### Evaluation Criteria
+## Section 6: Platform Adaptation — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -159,19 +126,7 @@ Ask via AskUserQuestion, **ONE AT A TIME:**
 
 **Section 6 Score: ___/10**
 
-### Action Classification
-
-- **AUTO:** Resolution inconsistencies in config, missing platform-specific settings
-- **ASK:** Input method priority, quality tier definitions, cert requirement decisions
-- **ESCALATE:** No certification awareness for console/mobile submission — guaranteed rejection
-
-**STOP.** One issue per AskUserQuestion.
-
----
-
-## Section 7: Testing Strategy (測試策略) — Weight: 10%
-
-### Evaluation Criteria
+## Section 7: Testing Strategy — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -183,24 +138,7 @@ Ask via AskUserQuestion, **ONE AT A TIME:**
 
 **Section 7 Score: ___/10**
 
-### Testing Red Flags
-
-- "We test by playing" — manual testing does not catch regressions
-- No CI pipeline — builds break silently
-- No crash reporting — bugs in the wild go undetected
-- No automated performance tests — frame rate regressions caught by players, not developers
-- Gameplay logic interleaved with rendering — untestable without full engine boot
-
-### Action Classification
-
-- **AUTO:** CI config errors, test framework setup issues
-- **ASK:** Test coverage priorities, CI/CD pipeline design, crash reporting tool selection
-- **ESCALATE:** No testing infrastructure AND approaching release
-
---
-| **Performance × GDD** | Does frame budget support the game's vision? | GDD promises 200 units on screen but frame budget only supports 50 |
-
-### Evaluation Criteria
+## Section 8: Cross-Section Consistency — Scoring Rubric
 
 | Criterion | Points | Deduction Rules |
 |-----------|--------|-----------------|
@@ -210,55 +148,30 @@ Ask via AskUserQuestion, **ONE AT A TIME:**
 
 **Section 8 Score: ___/10**
 
-### Action Classification
+## Weighted Total Formula
 
-- **AUTO:** Terminology inconsistencies across architecture sections
-- **ASK:** Cross-section design tensions that require architectural decisions
-- **ESCALATE:** Architecture fundamentally cannot support the game design — engine/network/performance limits conflict with GDD requirements
+```
+Architecture Health Score
+  Section 1 -- Engine & Framework:       _/10  (weight: W1%)  -> weighted: _.___
+  Section 2 -- Rendering & Performance:  _/10  (weight: W2%)  -> weighted: _.___
+  Section 3 -- Networking Architecture:  _/10  (weight: W3%)  -> weighted: _.___
+  Section 4 -- Data & Persistence:       _/10  (weight: W4%)  -> weighted: _.___
+  Section 5 -- Asset Pipeline:           _/10  (weight: W5%)  -> weighted: _.___
+  Section 6 -- Platform Adaptation:      _/10  (weight: W6%)  -> weighted: _.___
+  Section 7 -- Testing Strategy:         _/10  (weight: W7%)  -> weighted: _.___
+  Section 8 -- Cross-Consistency:        _/10  (weight: W8%)  -> weighted: _.___
 
-**STOP.** One issue per AskUserQuestion.
-
----
-
-## Required Outputs
-
-### Architecture Health Score
-
---
-  Section 8 — Cross-Consistency:        _/10  (weight: 10%)  → weighted: _.___
-  ─────────────────────────────────────────────
   WEIGHTED TOTAL:                       _._/10
-
-  * If Section 3 is N/A (single-player), redistribute 15% weight:
-    Rendering +5%, Data +5%, Testing +5%
-
-Score Interpretation:
-  8.0-10.0  PRODUCTION-READY — Architecture supports the game design, well-documented
-  6.0-7.9   SOLID — Good foundation, address flagged issues before scaling team
-  4.0-5.9   NEEDS WORK — Significant gaps that will cause production bottlenecks
-  2.0-3.9   MAJOR REVISION — Architectural decisions need rethinking
-  0.0-1.9   START OVER — No architecture yet, just technology choices
-
-Top 3 Deductions (biggest point losses):
-  1. [Section] [Criterion]: -N because [specific reason]
-  2. [Section] [Criterion]: -N because [specific reason]
-  3. [Section] [Criterion]: -N because [specific reason]
---
-  Section 8 — Cross-Consistency:        _/10, ___ contradictions found
-
-WEIGHTED TOTAL: _._/10
-
-Status: DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT
 ```
 
-**Status definitions:**
-- **DONE** — All sections reviewed, all critical issues resolved, Architecture Health Score >= 6.0
-- **DONE_WITH_CONCERNS** — All sections reviewed, some issues deferred, score 4.0-5.9
-- **BLOCKED** — Review could not complete due to ESCALATE items (engine cannot support GDD, no performance targets, fundamental architecture mismatch)
-- **NEEDS_CONTEXT** — Review paused because critical context is missing (no target platforms, no performance targets, no GDD)
+Use the mode weight adjustments table above — do NOT use default weights blindly. If Section 3 is N/A (single-player), use the mode-specific column which already redistributes that weight.
 
-### NOT in Scope
+## Score Interpretation
 
-List deferred work with rationale:
-```
-- [Issue]: Deferred because [reason]. Revisit when [condition].
+| Range | Label | Meaning |
+|-------|-------|---------|
+| 8.0-10.0 | PRODUCTION-READY | Architecture supports the game design, well-documented |
+| 6.0-7.9 | SOLID | Good foundation, address flagged issues before scaling team |
+| 4.0-5.9 | NEEDS WORK | Significant gaps that will cause production bottlenecks |
+| 2.0-3.9 | MAJOR REVISION | Architectural decisions need rethinking |
+| 0.0-1.9 | START OVER | No architecture yet, just technology choices |


### PR DESCRIPTION
## Summary

- Add 3 reference files to `skills/game-eng-review/references/`: scoring rubrics with mode weight adjustments, Claude-specific architecture review gotchas (9 items), and canonical platform performance budgets (frame, draw call, memory, texture, build size)
- Slim template from 589L to 464L by extracting inline rubric tables and anti-sycophancy protocol to reference files
- Add "Load References" section to template for progressive disclosure

Implements Phase 1 of #4. Phase 2 (networking-patterns.md, engine-framework.md) and Phase 3 (remaining 5 reference files) will be tracked as separate issues.

## Test plan

- [x] `bun run build` succeeds — SKILL.md regenerated correctly
- [x] `bun test` — 10/11 pass (1 pre-existing failure unrelated to this change)
- [ ] Manual review: reference file cross-links are correct (scoring.md references performance-budgets.md)
- [ ] Manual review: template still reads coherently with inline rubrics replaced by references

🤖 Generated with [Claude Code](https://claude.com/claude-code)