### PR TITLE
feat(game-eng-review): Phase 2 — networking patterns + engine framework refs

### DIFF
--- a/skills/game-eng-review/SKILL.md
+++ b/skills/game-eng-review/SKILL.md
@@ -190,6 +190,8 @@ Read these reference files before starting the review — they contain scoring r
 - `references/scoring.md` — All 8 section rubrics with mode weight adjustments and scoring notes
 - `references/gotchas.md` — Claude-specific architecture review mistakes, anti-sycophancy protocol, forcing question routing
 - `references/performance-budgets.md` — Frame budgets, draw call limits, memory ceilings, texture sizes, build size limits by platform
+- `references/networking-patterns.md` — Networking models, tick rates, prediction/compensation, bandwidth budgets, latency thresholds
+- `references/engine-framework.md` — Engine selection matrix, Unity/Godot/Unreal architectural patterns, build pipeline
 
 > **Anti-sycophancy and push-back cadence:** See `references/gotchas.md`. Follow the forbidden phrases list and push-back cadence for EVERY interaction.
 
@@ -343,15 +345,7 @@ Push until you hear: A graceful degradation strategy. Dynamic resolution? Partic
 
 **Skip this section if the game is single-player only.** Score as N/A and redistribute weight per mode table in `references/scoring.md`.
 
-First, classify the networking model:
-
-| Model | Latency Tolerance | Bandwidth | Complexity | Example |
-|-------|-------------------|-----------|------------|---------|
-| **Client-Server Authoritative** | Low (action games) | High | High | Overwatch, Valorant |
-| **Client-Server Relaxed** | Medium (RPGs, strategy) | Medium | Medium | World of Warcraft, Clash Royale |
-| **Peer-to-Peer** | Variable | Low | Medium | Fighting games (GGPO), co-op |
-| **Turn-Based** | High (async OK) | Low | Low | Hearthstone, chess |
-| **Async/Social** | Very High | Very Low | Low | Clash of Clans attacks, leaderboards |
+First, classify the networking model using `references/networking-patterns.md` (Networking Models Comparison table). Match the game's latency sensitivity and player count to the appropriate model. Check tick rates, prediction models, and bandwidth budgets against the reference tables.
 
 > **Scoring:** See `references/scoring.md`, Section 3. Five criteria: Model Fitness (0-3), State Synchronization (0-2), Latency Handling (0-2), Cheat Prevention (0-2), Failure Modes (0-1). Total: ___/10.
 

--- a/skills/game-eng-review/SKILL.md.tmpl
+++ b/skills/game-eng-review/SKILL.md.tmpl
@@ -55,6 +55,8 @@ Read these reference files before starting the review — they contain scoring r
 - `references/scoring.md` — All 8 section rubrics with mode weight adjustments and scoring notes
 - `references/gotchas.md` — Claude-specific architecture review mistakes, anti-sycophancy protocol, forcing question routing
 - `references/performance-budgets.md` — Frame budgets, draw call limits, memory ceilings, texture sizes, build size limits by platform
+- `references/networking-patterns.md` — Networking models, tick rates, prediction/compensation, bandwidth budgets, latency thresholds
+- `references/engine-framework.md` — Engine selection matrix, Unity/Godot/Unreal architectural patterns, build pipeline
 
 > **Anti-sycophancy and push-back cadence:** See `references/gotchas.md`. Follow the forbidden phrases list and push-back cadence for EVERY interaction.
 
@@ -208,15 +210,7 @@ Push until you hear: A graceful degradation strategy. Dynamic resolution? Partic
 
 **Skip this section if the game is single-player only.** Score as N/A and redistribute weight per mode table in `references/scoring.md`.
 
-First, classify the networking model:
-
-| Model | Latency Tolerance | Bandwidth | Complexity | Example |
-|-------|-------------------|-----------|------------|---------|
-| **Client-Server Authoritative** | Low (action games) | High | High | Overwatch, Valorant |
-| **Client-Server Relaxed** | Medium (RPGs, strategy) | Medium | Medium | World of Warcraft, Clash Royale |
-| **Peer-to-Peer** | Variable | Low | Medium | Fighting games (GGPO), co-op |
-| **Turn-Based** | High (async OK) | Low | Low | Hearthstone, chess |
-| **Async/Social** | Very High | Very Low | Low | Clash of Clans attacks, leaderboards |
+First, classify the networking model using `references/networking-patterns.md` (Networking Models Comparison table). Match the game's latency sensitivity and player count to the appropriate model. Check tick rates, prediction models, and bandwidth budgets against the reference tables.
 
 > **Scoring:** See `references/scoring.md`, Section 3. Five criteria: Model Fitness (0-3), State Synchronization (0-2), Latency Handling (0-2), Cheat Prevention (0-2), Failure Modes (0-1). Total: ___/10.
 
@@ -405,6 +399,10 @@ Section Results:
 WEIGHTED TOTAL: _._/10
 
 Status: DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT
+
+Next Step:
+  PRIMARY: /prototype-slice-plan — architecture validated, plan what to build
+  (if critical tech debt): fix debt first, then re-run /game-eng-review
 ```
 
 **Status definitions:**

--- a/skills/game-eng-review/references/engine-framework.md
+++ b/skills/game-eng-review/references/engine-framework.md
@@ -1,0 +1,113 @@
+# Engine & Framework Reference
+
+## Engine Selection Decision Matrix
+
+| Factor | Unity | Godot | Unreal Engine | Custom Engine |
+|--------|-------|-------|---------------|---------------|
+| **Team Size Sweet Spot** | 1-50 | 1-10 | 10-200+ | 5-20 (experienced) |
+| **2D Support** | Strong (Tilemap, SpriteRenderer, 2D physics) | Excellent (native 2D pipeline, not retrofitted) | Weak (Paper2D deprecated in spirit) | Depends on implementation |
+| **3D Support** | Good (URP/HDRP, adequate for most) | Improving (Vulkan renderer, but behind) | Excellent (Nanite, Lumen, best-in-class) | Depends on implementation |
+| **Mobile** | Proven (majority of mobile games) | Usable (export quality improving) | Possible but heavy (runtime size, thermal) | Lightweight if built for it |
+| **Console** | Supported (Switch, PS, Xbox) | PS/Xbox in progress, Switch partial | Full support (native console tooling) | Requires per-platform SDK licensing |
+| **Web/WebGL** | Supported (large build sizes) | Supported (smaller builds) | Not supported | Possible if designed for it |
+| **Learning Curve** | Medium (C#, large API surface) | Low (GDScript intuitive, small API) | High (C++, Blueprint, massive framework) | N/A (you build the curve) |
+| **License Cost** | Free under $200K/yr revenue, then 2.5% | Free (MIT, forever) | Free under $1M revenue, then 5% | Free (but you pay in dev time) |
+| **Asset Ecosystem** | Large (Asset Store, mature) | Growing (Asset Library, smaller) | Large (Marketplace, high-quality) | None (build everything) |
+| **CI/CD** | Moderate (Unity Build Server licensing) | Good (command-line export, no extra license) | Complex (large builds, UGS or custom) | Full control |
+
+### When to Choose Each
+
+- **Unity:** Mobile-first games, 2D or mid-fidelity 3D, team has C# experience, need broad platform reach.
+- **Godot:** Small team, 2D games, prototyping, open-source requirement, budget-conscious, web export important.
+- **Unreal:** High-fidelity 3D, team has C++ experience or dedicated Blueprint designers, console AAA, need Nanite/Lumen/MetaHuman.
+- **Custom engine:** Team has prior engine experience AND the game has a specific technical need no existing engine serves (e.g., voxel engine, custom physics, extreme performance requirement). Red flag if chosen for "control" without a specific technical justification.
+
+## Engine-Specific Architectural Patterns
+
+### Unity
+
+| Pattern | When to Use | When to Avoid |
+|---------|------------|---------------|
+| **MonoBehaviour (classic)** | Small projects, prototypes, <50 active GameObjects | Performance-critical systems with 1000+ entities |
+| **ECS (DOTS/Entities)** | Mass entity simulation (bullets, particles, crowds) | Simple games where MonoBehaviour is sufficient; API still evolving |
+| **ScriptableObjects for Data** | Game config, item databases, ability definitions, shared state | Runtime-generated data that changes per-play |
+| **Addressables** | DLC, asset streaming, reducing build size, platform-specific assets | Small projects where Resources folder is sufficient |
+| **IL2CPP** | Release builds (required for iOS, recommended everywhere) | Development iteration (use Mono for fast compile) |
+| **Assembly Definitions** | Projects with >20 scripts (controls recompilation scope) | Tiny projects where compile time is already instant |
+
+**Unity gotchas:**
+- GC allocations in Update/FixedUpdate cause frame hitches. Profile with Deep Profile; cache GetComponent results.
+- Coroutines allocate on start. For frequent short timers, use a timer manager or UniTask.
+- String operations (concatenation, ToString) allocate. Use StringBuilder or interpolated strings with caution in hot paths.
+- DOTS/Entities API changes between versions. Pin your Entities package version; do not auto-update.
+
+### Godot
+
+| Pattern | When to Use | When to Avoid |
+|---------|------------|---------------|
+| **Node tree composition** | Standard game objects (player, enemies, UI) | Flat data processing (use arrays/dictionaries) |
+| **Signals** | Loose coupling between nodes (UI updates, events) | High-frequency per-frame communication (direct call faster) |
+| **Direct method calls** | Performance-critical per-frame logic | Cross-system communication (creates tight coupling) |
+| **GDScript** | Gameplay logic, prototyping, most game code | CPU-intensive algorithms (pathfinding, procedural gen) |
+| **C# (.NET)** | CPU-heavy systems, team knows C#, sharing code with server | Simple projects where GDScript is sufficient |
+| **GDExtension (C/C++)** | Maximum performance for specific bottleneck systems | General game logic (overkill, slow iteration) |
+| **Autoloads (singletons)** | Global managers (audio, save system, scene transitions) | More than 5-7 autoloads (becomes implicit dependency web) |
+
+**Godot gotchas:**
+- GDScript is ~10-100x slower than C++ for computation. Profile before rewriting in C# — the bottleneck may be elsewhere.
+- Node tree depth affects performance. Deep trees with many children slow down scene tree operations. Flatten where possible.
+- Exported properties reset when script changes in certain cases. Use resource files for important data.
+- 3D renderer is less mature than Unity/Unreal. Test on target hardware early, especially for mobile 3D.
+
+### Unreal Engine
+
+| Pattern | When to Use | When to Avoid |
+|---------|------------|---------------|
+| **Blueprint** | Rapid prototyping, designer-tunable logic, UI, simple gameplay | Performance-critical loops, complex algorithms |
+| **C++** | Core systems, performance-critical code, engine-level features | Simple one-off logic that designers need to tweak |
+| **Blueprint/C++ boundary** | C++ base class + Blueprint-exposed functions + Blueprint subclass | Putting ALL logic in one layer |
+| **GameplayAbilitySystem (GAS)** | RPGs, action games with many abilities, buff/debuff systems | Simple games with <5 player actions |
+| **Data Assets / Data Tables** | Item databases, enemy stats, level configs, localization | Runtime-generated data |
+| **Subsystems** | Game-wide services (inventory, quest, matchmaking) | Per-actor logic (use components) |
+| **Gameplay Tags** | Categorizing abilities, states, items without hard enums | Simple bool flags where an enum suffices |
+
+**Unreal gotchas:**
+- Blueprint tick is ~10x slower than C++ tick. Move anything called per-frame to C++ or use timers.
+- Binary asset format means merge conflicts on Blueprints/levels are unresolvable. Use strict asset locking workflow.
+- Nanite/Lumen require modern GPUs (RTX 2060+ or equivalent). If targeting older hardware, plan fallback rendering.
+- Build sizes start at 100-200MB minimum (engine runtime). Not suitable for small web or mobile games.
+- Full C++ recompile can take 5-30 minutes. Use Live Coding and modular build targets to reduce iteration time.
+
+## Engine-Agnostic Architecture Patterns
+
+| Pattern | Description | Best For | Watch Out |
+|---------|-------------|----------|-----------|
+| **Component-Based** | Entities composed of reusable behavior components | Most games; flexible, composable | Deep component chains become hard to debug |
+| **ECS (Entity Component System)** | Data-oriented: entities are IDs, components are data, systems process data | Mass simulation (1000+ entities), cache-friendly | Over-engineering for simple games; paradigm shift for OOP teams |
+| **State Machines (FSM/HSM)** | Explicit states with defined transitions | AI behavior, game flow, animation | State explosion for complex behavior; consider behavior trees |
+| **Event Bus / Message Bus** | Central dispatcher for decoupled communication | Cross-system events (UI updates, achievements, analytics) | Debugging invisible event chains; untyped events hide errors |
+| **Service Locator** | Global registry of services, retrieved by interface | Dependency injection without framework; testable singletons | Hides dependencies; can become a god object if abused |
+| **Object Pooling** | Pre-allocate and recycle frequently created/destroyed objects | Bullets, particles, enemies, any high-frequency spawn/despawn | Pool size tuning; stale state bugs from recycled objects |
+| **Command Pattern** | Encapsulate actions as objects | Undo/redo, replay systems, input buffering, network commands | Overhead for simple one-shot actions |
+
+## Build Pipeline Considerations
+
+### CI/CD for Games
+
+| Stage | What It Does | Tools / Approach |
+|-------|-------------|-----------------|
+| **Source Build** | Compile code, verify no errors | Engine CLI build (Unity: `-batchmode -buildTarget`, Godot: `--headless --export`, Unreal: BuildCookRun) |
+| **Asset Bake** | Process art assets, compress textures, build atlases | Engine import pipeline; can take 10-60 minutes for large projects |
+| **Automated Tests** | Run unit tests, integration tests, smoke tests | Engine test frameworks (Unity Test Runner, GUT for Godot, Automation for Unreal) |
+| **Platform Builds** | Build per-platform binaries | Separate build agents per platform; console builds require devkit hardware |
+| **Size Check** | Verify build size within store limits | Script that checks output size against budget; fail build if exceeded |
+| **Distribution** | Push to testers, staging, or store | Steam Depot, TestFlight, Google Play internal testing, itch.io butler |
+
+**Key rule:** If a build takes >30 minutes, the team will stop running it frequently. Optimize build pipeline early — it determines iteration speed for the entire project.
+
+### Platform-Specific Build Notes
+
+- **iOS:** Requires macOS build agent. Code signing and provisioning profiles expire and break CI silently. Automate renewal.
+- **Android:** Multiple ABIs (arm64, x86_64). Test APK size against Play Store limits per ABI. AAB format recommended.
+- **Console:** Devkit hardware required for builds. Cannot run in cloud CI without special (expensive) arrangements.
+- **WebGL/Web:** Build size directly impacts load time. Every MB = ~1 second on average broadband. Tree-shake aggressively.

--- a/skills/game-eng-review/references/networking-patterns.md
+++ b/skills/game-eng-review/references/networking-patterns.md
@@ -1,0 +1,99 @@
+# Networking Patterns Reference
+
+## Networking Models Comparison
+
+| Model | Authority | Latency Tolerance | Bandwidth | Complexity | Best For | Drawbacks |
+|-------|-----------|-------------------|-----------|------------|----------|-----------|
+| **Client-Server Authoritative** | Server owns all game state | Low (<100ms) | High | High | Competitive FPS, MOBA, arena | Server cost scales with players; requires prediction |
+| **Client-Server Relaxed** | Server owns critical state, client owns cosmetic | Medium (<200ms) | Medium | Medium | MMO, co-op RPG, social games | Cheat surface on client-owned state |
+| **Peer-to-Peer (Mesh)** | Each peer owns their state | Variable | Low per-peer | Medium | Co-op (2-4 players), LAN games | NAT traversal pain; no cheat prevention; scales poorly past 4 |
+| **Peer-to-Peer (Relay)** | Peers via relay server | Variable + relay hop | Low | Medium | Fighting games, small lobbies | Relay adds latency; still need NAT fallback |
+| **Dedicated Server** | Server-authoritative + hosted | Low (<100ms) | High | High | Large-scale multiplayer, esports | Hosting cost; geographic distribution needed |
+| **Lockstep** | Deterministic simulation | Depends on slowest peer | Very Low (inputs only) | High (determinism) | RTS, turn-based strategy | Requires full determinism; one slow peer stalls all |
+| **Turn-Based / Async** | Server validates turns | Very High (seconds-hours) | Very Low | Low | Card games, board games, async PvP | Not suitable for real-time action |
+
+**Selection rule:** Match the model to the game's latency sensitivity and player count. Over-engineering networking (authoritative server for a 2-player co-op) wastes budget. Under-engineering it (P2P for competitive 10v10) guarantees cheating and desync.
+
+## Tick Rates by Game Type
+
+| Game Type | Tick Rate | Rationale |
+|-----------|-----------|-----------|
+| Competitive FPS | 64-128 Hz | Precise hit detection requires sub-frame accuracy |
+| Arena / MOBA | 30-60 Hz | Lower precision needs than FPS; 30Hz sufficient for most |
+| Racing | 30-60 Hz | Physics interpolation smooths visual result |
+| Action RPG / Co-op | 20-30 Hz | Combat timing less precise; lower rate saves bandwidth |
+| RTS | 10-20 Hz | Unit commands batch well; lockstep often preferred |
+| MMO (world state) | 10-30 Hz | Hundreds of entities; lower rate mandatory for bandwidth |
+| Turn-Based | On-demand | No fixed tick; send on action |
+| Social / Async | On-demand | Polling or push notifications |
+
+**Key trade-off:** Higher tick rate = more responsive feel but more bandwidth and server CPU. Double the tick rate roughly doubles bandwidth. Do not exceed what the game's precision needs demand.
+
+## Prediction & Compensation Models
+
+| Model | How It Works | When to Use | When NOT to Use |
+|-------|-------------|-------------|-----------------|
+| **Client-Side Prediction** | Client simulates locally, server corrects | Any real-time client-server game | Turn-based; lockstep (redundant) |
+| **Server Reconciliation** | Client replays from last confirmed state on correction | Paired with client-side prediction | Games without prediction |
+| **Entity Interpolation** | Render other entities between two known server states | Smoothing remote player movement | Local player (use prediction instead) |
+| **Rollback Netcode (GGPO)** | Re-simulate from last confirmed input on misprediction | Fighting games, 1v1 action, small player count | Large player counts (rollback cost scales with entities) |
+| **Lockstep Deterministic** | All peers execute same inputs, same frame | RTS, simulations requiring identical state | Action games needing instant local response |
+| **Dead Reckoning** | Extrapolate position from velocity/acceleration | Vehicle movement, slow-moving entities | Fast direction changes, precise combat |
+| **Lag Compensation (Rewind)** | Server rewinds time to validate client actions | FPS hit detection (what the shooter saw) | Non-combat interactions |
+
+**Common mistake:** Implementing client-side prediction without server reconciliation. Prediction without correction means the client drifts from truth and snaps back violently on every correction.
+
+## Bandwidth Budgets by Platform
+
+| Network Context | Per-Player Budget | Notes |
+|----------------|-------------------|-------|
+| Mobile (cellular 4G) | 1-5 KB/s | Carriers may throttle sustained connections; packet loss 1-5% |
+| Mobile (cellular 5G) | 5-20 KB/s | Lower latency but still variable; do not assume desktop-like |
+| Mobile (WiFi) | 10-50 KB/s | Shared bandwidth; apartment WiFi can be worse than cellular |
+| PC (broadband) | 50-200 KB/s | Generous but still budget — 64-player server at 200KB/s = 12.5 MB/s out |
+| Console (broadband) | 50-200 KB/s | Similar to PC; some ISPs have data caps |
+| LAN | 500+ KB/s | Effectively unlimited for game data |
+
+**Budget math:** Total server outbound = per-player budget x max players x tick rate overhead. A 64-player server sending 100 KB/s per player = 6.4 MB/s outbound. Verify hosting can sustain this.
+
+### Bandwidth Reduction Strategies
+
+- **Delta compression:** Send only what changed since last acknowledged state. Typical 60-80% reduction.
+- **Interest management / relevance:** Only send entities within player's area of interest. Critical for MMOs and large maps.
+- **Quantization:** Reduce float precision (position to 0.01 units, rotation to 1 degree). 50%+ reduction for position data.
+- **Variable tick rate:** Full updates at 10Hz, critical updates (hits, deaths) immediately.
+- **Bit packing:** Pack multiple small values into single bytes. Avoid sending full 32-bit ints for values that fit in 4 bits.
+
+## Latency Thresholds by Game Type
+
+| Game Type | Acceptable | Noticeable | Unplayable | Notes |
+|-----------|-----------|------------|------------|-------|
+| Competitive FPS | <50ms | 50-100ms | >150ms | Includes both network RTT and display latency |
+| Fighting Games | <80ms | 80-130ms | >130ms | Rollback extends acceptable range by ~50ms |
+| MOBA / Arena | <80ms | 80-150ms | >200ms | Ability queuing helps mask latency |
+| Action RPG / Co-op | <100ms | 100-200ms | >300ms | PvE more forgiving than PvP |
+| Racing | <100ms | 100-200ms | >250ms | Ghost/rubber-banding visible at high latency |
+| RTS | <150ms | 150-300ms | >500ms | Lockstep adds input delay equal to RTT/2 |
+| MMO (general play) | <200ms | 200-400ms | >500ms | Social/exploration very tolerant |
+| Turn-Based | <500ms | 500ms-2s | >5s | Feedback speed matters more than precision |
+| Card Games | <1s | 1-3s | >5s | Animation timing masks most latency |
+
+**Design implication:** If your game requires <100ms and your target audience includes players 200ms apart geographically, you need regional servers or relay routing. No amount of prediction fixes physics.
+
+## Common Networking Gotchas
+
+1. **Floating-point non-determinism.** Different CPUs produce different float results for the same operation. Lockstep games MUST use fixed-point math or guarantee identical hardware. This breaks cross-platform lockstep (PC vs mobile).
+
+2. **Hash map / dictionary iteration order.** Unordered containers iterate differently across platforms, compilers, and even runs. Lockstep simulations using hash maps for entity storage will desync silently.
+
+3. **Event ordering assumptions.** "Player A fires, Player B moves" may arrive in different order on different clients. All gameplay events must be ordered by tick/sequence number, not arrival time.
+
+4. **Clock drift.** Client and server clocks diverge over time. NTP sync is not sufficient for game timing — implement game-tick synchronization separate from wall-clock time.
+
+5. **MTU fragmentation.** Packets over ~1200 bytes risk fragmentation across network hops. Fragment = retransmit = latency spike. Keep individual messages under MTU. If you must send large data, implement your own fragmentation with reliability.
+
+6. **NAT traversal failure rates.** Symmetric NAT (common on mobile carriers) fails hole-punching ~30% of the time. Any P2P game needs a relay fallback or players will report "can't connect."
+
+7. **Head-of-line blocking (TCP).** TCP guarantees order — one lost packet blocks all subsequent packets. Game networking should use UDP with selective reliability, not TCP. Only use TCP for non-latency-sensitive data (chat, login, matchmaking).
+
+8. **State explosion at scale.** Sending full world state works for 2-4 players. At 64+ players, you must implement interest management (spatial partitioning, relevance filtering) or bandwidth explodes combinatorially.


### PR DESCRIPTION
## Summary

Phase 2 of #4. Adds 2 reference files to game-eng-review.

### Changes
- `skills/game-eng-review/references/networking-patterns.md` (~99L) — networking models comparison, tick rates by game type, prediction/compensation models, bandwidth budgets by platform, latency thresholds, common networking gotchas
- `skills/game-eng-review/references/engine-framework.md` (~113L) — engine selection decision matrix (Unity/Godot/Unreal/custom), engine-specific architectural patterns and gotchas, engine-agnostic patterns, build pipeline considerations
- `skills/game-eng-review/SKILL.md.tmpl` — added references to new files in Load References section; replaced inline networking model table with pointer to networking-patterns.md (~464L -> ~458L)

### Verification
- [x] `bun run build` passes
- [x] `bun test` passes (11/11)

Phase 3 (remaining 5 files) needs domain expert input — will be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)