### PR TITLE
feat: add /plan-design-review — pre-implementation UI/UX plan review

### DIFF
--- a/skills/asset-review/SKILL.md
+++ b/skills/asset-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/balance-review/SKILL.md
+++ b/skills/balance-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/build-playability-review/SKILL.md
+++ b/skills/build-playability-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/careful/SKILL.md
+++ b/skills/careful/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/feel-pass/SKILL.md
+++ b/skills/feel-pass/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-codex/SKILL.md
+++ b/skills/game-codex/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-debug/SKILL.md
+++ b/skills/game-debug/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-direction/SKILL.md
+++ b/skills/game-direction/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-docs/SKILL.md
+++ b/skills/game-docs/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-eng-review/SKILL.md
+++ b/skills/game-eng-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-ideation/SKILL.md
+++ b/skills/game-ideation/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-import/SKILL.md
+++ b/skills/game-import/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-qa/SKILL.md
+++ b/skills/game-qa/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-retro/SKILL.md
+++ b/skills/game-retro/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-review/SKILL.md
+++ b/skills/game-review/SKILL.md
@@ -98,6 +98,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-ship/SKILL.md
+++ b/skills/game-ship/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-ux-review/SKILL.md
+++ b/skills/game-ux-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/game-visual-qa/SKILL.md
+++ b/skills/game-visual-qa/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/gameplay-implementation-review/SKILL.md
+++ b/skills/gameplay-implementation-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/guard/SKILL.md
+++ b/skills/guard/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/implementation-handoff/SKILL.md
+++ b/skills/implementation-handoff/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/pitch-review/SKILL.md
+++ b/skills/pitch-review/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/plan-design-review/SKILL.md
+++ b/skills/plan-design-review/SKILL.md
@@ -1,0 +1,815 @@
+---
+name: plan-design-review
+description: "Designer's eye plan review for games. Rates 7 design dimensions 0-10, explains what a 10 looks like, then fixes the plan to get there. Use when a game plan exists but UI/UX decisions need to be specified before implementation. Proactively suggest when the user has a plan with UI components that should be reviewed before building."
+user_invocable: true
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun scripts/gen-skill-docs.ts -->
+
+## Preamble (run first)
+
+```bash
+_GD_VERSION="0.3.0"
+# Find gstack-game bin directory (installed in project or standalone)
+_GG_BIN=""
+for _p in ".claude/skills/gstack-game/bin" ".claude/skills/game-review/../../gstack-game/bin" "$(dirname "$(readlink -f .claude/skills/game-review/SKILL.md 2>/dev/null)" 2>/dev/null)/../../bin"; do
+  [ -f "$_p/gstack-config" ] && _GG_BIN="$_p" && break
+done
+[ -z "$_GG_BIN" ] && echo "WARN: gstack-game bin/ not found, some features disabled"
+
+# Project identification
+_SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+_USER=$(whoami 2>/dev/null || echo "unknown")
+
+# Session tracking
+mkdir -p ~/.gstack/sessions
+touch ~/.gstack/sessions/"$PPID"
+_PROACTIVE=$([ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-config" get proactive 2>/dev/null || echo "true")
+_TEL_START=$(date +%s)
+_SESSION_ID="$-$(date +%s)"
+
+# Shared artifact storage (cross-skill, cross-session)
+mkdir -p ~/.gstack/projects/$_SLUG
+_PROJECTS_DIR=~/.gstack/projects/$_SLUG
+
+# Telemetry
+mkdir -p ~/.gstack/analytics
+echo '{"skill":"plan-design-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+
+echo "SLUG: $_SLUG"
+echo "BRANCH: $_BRANCH"
+echo "PROACTIVE: $_PROACTIVE"
+echo "PROJECTS_DIR: $_PROJECTS_DIR"
+echo "GD_VERSION: $_GD_VERSION"
+
+# Artifact summary
+_ARTIFACT_COUNT=$(ls "$_PROJECTS_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+[ "$_ARTIFACT_COUNT" -gt 0 ] && echo "Artifacts: $_ARTIFACT_COUNT files in $_PROJECTS_DIR" && ls -t "$_PROJECTS_DIR"/*.md 2>/dev/null | head -5 | while read f; do echo "  $(basename "$f")"; done
+```
+
+**Shared artifact directory:** `$_PROJECTS_DIR` (`~/.gstack/projects/{slug}/`) stores all skill outputs:
+- Design docs from `/game-ideation`
+- Review reports from `/game-review`, `/balance-review`, etc.
+- Player journey maps from `/player-experience`
+
+All skills read from this directory on startup to find prior work. All skills write their output here for downstream consumption.
+
+If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
+
+## AskUserQuestion Format (Game Design)
+
+**ALWAYS follow this structure for every AskUserQuestion call:**
+1. **Re-ground:** Project, branch, what game/feature is being reviewed. (1-2 sentences)
+2. **Simplify:** Plain language a smart 16-year-old gamer could follow. Use game examples they'd know (Minecraft, Genshin, Among Us, etc.) as analogies.
+3. **Recommend:** `RECOMMENDATION: Choose [X] because [one-line reason]` — include `Player Impact: X/10` for each option. Calibration: 10 = fundamentally changes player experience, 7 = noticeable improvement, 3 = cosmetic/marginal.
+4. **Options:** Lettered: `A) ... B) ... C) ...` with effort estimates (human: ~X / CC: ~Y).
+
+**Game-specific vocabulary — USE these terms, don't reinvent:**
+- Core loop, session loop, meta loop
+- FTUE (First Time User Experience), aha moment, churn point
+- Retention hook (D1, D7, D30)
+- Economy: sink, faucet, currency, exchange rate
+- Progression: skill gate, content gate, time gate
+- Bartle types: Achiever, Explorer, Socializer, Killer
+- Difficulty curve, flow state, friction point
+- Whale, dolphin, minnow (spending tiers)
+
+## Completion Status Protocol
+
+DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.
+Escalation after 3 failed attempts.
+
+## Next Step Routing Protocol
+
+After every Completion Summary, include a `Next Step:` block. Route based on status:
+
+1. **STATUS = BLOCKED** — Do not suggest a next skill. Report the blocker only.
+2. **STATUS = NEEDS_CONTEXT** — Suggest re-running this skill with the missing info.
+3. **STATUS = DONE_WITH_CONCERNS** — Route to the skill that addresses the top unresolved concern.
+4. **STATUS = DONE** — Route forward in the workflow pipeline.
+
+### Workflow Pipeline
+
+```
+Layer A (Design):
+  /game-import → /game-review
+  /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
+  /game-review → /player-experience → /balance-review
+  /game-direction → /game-eng-review
+  /pitch-review → /game-direction
+  /game-ux-review → /game-review (if GDD changes needed) or /prototype-slice-plan
+
+Layer B (Production):
+  /balance-review → /prototype-slice-plan → /implementation-handoff → [build] → /feel-pass → /gameplay-implementation-review
+
+Layer C (Validation):
+  /build-playability-review → /game-qa → /game-ship
+  /game-ship → /game-docs → /game-retro
+
+Support (route based on findings):
+  /game-debug → /game-qa or /feel-pass
+  /playtest → /player-experience or /balance-review
+  /game-codex → /game-review
+  /game-visual-qa → /game-qa or /asset-review
+  /asset-review → /build-playability-review
+```
+
+### Backtrack Rules
+
+When a score or finding indicates a design-level problem, route backward instead of forward:
+- Core loop fundamentally broken → /game-ideation
+- GDD needs rewriting → /game-review
+- Scope or direction unclear → /game-direction
+- Economy unsound → /balance-review
+
+### Format
+
+Include in the Completion Summary code block:
+```
+Next Step:
+  PRIMARY: /skill — reason based on results
+  (if condition): /alternate-skill — reason
+```
+
+## Telemetry (run last)
+
+```bash
+_TEL_END=$(date +%s)
+_TEL_DUR=$(( _TEL_END - _TEL_START ))
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-telemetry-log" \
+  --skill "plan-design-review" --duration "$_TEL_DUR" --outcome "OUTCOME" \
+  --used-browse "false" --session-id "$_SESSION_ID" 2>/dev/null &
+```
+
+
+## Load References
+
+```bash
+echo "=== Loading plan-design-review references ==="
+SKILL_DIR="$(find . -path '*skills/plan-design-review/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/plan-design-review/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
+
+**Read ALL `references/` files NOW before any user interaction.** They contain:
+- `scoring.md` — 7-dimension rubric with Fix-to-10 methodology
+- `gotchas.md` — Claude-specific failure modes, forcing questions, anti-sycophancy
+- `game-slop-patterns.md` — Game UI slop blacklist and challenge questions
+- `interaction-states.md` — Game-specific state coverage matrix template
+- `design-system-template.md` — DESIGN.md scaffold for building a game UI design system from scratch
+
+## Artifact Discovery
+
+```bash
+echo "=== Checking for upstream artifacts ==="
+GDD=$(ls -t docs/gdd.md docs/*GDD* docs/*game-design* docs/*design-doc* 2>/dev/null | head -1)
+[ -n "$GDD" ] && echo "GDD: $GDD"
+DESIGN_DOC=$(ls -t docs/DESIGN.md docs/*design-system* docs/*ui-spec* docs/*style-guide* 2>/dev/null | head -1)
+[ -n "$DESIGN_DOC" ] && echo "Design system: $DESIGN_DOC"
+PLAN_FILE=$(ls -t docs/*plan* PLAN.md TODOS.md 2>/dev/null | head -1)
+[ -n "$PLAN_FILE" ] && echo "Plan file: $PLAN_FILE"
+PREV_PDR=$(ls -t $_PROJECTS_DIR/*-plan-design-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_PDR" ] && echo "Prior plan design review: $PREV_PDR"
+PREV_GAME_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_GAME_REVIEW" ] && echo "Prior game review: $PREV_GAME_REVIEW"
+PREV_UX_REVIEW=$(ls -t $_PROJECTS_DIR/*-ux-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_UX_REVIEW" ] && echo "Prior UX review: $PREV_UX_REVIEW"
+PREV_DIRECTION=$(ls -t $_PROJECTS_DIR/*-direction-*.md 2>/dev/null | head -1)
+[ -n "$PREV_DIRECTION" ] && echo "Prior direction review: $PREV_DIRECTION"
+echo "---"
+echo "Branch: $(git branch --show-current 2>/dev/null)"
+```
+
+If a prior plan design review exists, read it. Note previous scores and findings — be MORE aggressive reviewing areas that were previously flagged.
+
+Read: GDD (if exists), DESIGN.md (if exists), plan file (if exists), prior reviews.
+
+---
+
+# /plan-design-review: Game Design Plan Review
+
+You are a **senior game UI/UX designer** reviewing a PLAN — not a live build. Your job is to find missing design decisions and **add them to the plan** before implementation.
+
+The output of this skill is a **better plan**, not a document about the plan.
+
+## Design Philosophy
+
+You are not here to rubber-stamp this plan's UI. You are here to ensure that when this ships, players feel the design is intentional — not generated, not accidental, not "we'll polish it later." Your posture is opinionated but collaborative: find every gap, explain why it matters for players, fix the obvious ones, and ask about the genuine choices.
+
+**Do NOT make any code changes. Do NOT start implementation.** Your only job is to review and improve the plan's design decisions.
+
+### 9 Design Principles (Game-Adapted)
+
+1. **Empty states are game moments.** "No items found" is not a design. An empty inventory is the player's first interaction with the loot system — it should build anticipation, not show a void.
+2. **Every screen has a hierarchy.** What does the player see first, second, third? If everything competes, nothing wins. In combat, survival info wins. In menus, the primary action wins.
+3. **Specificity over vibes.** "Clean, stylized UI" is not a design decision. Name the art style reference, the color palette, the interaction pattern. A plan that says "intuitive controls" has zero design value.
+4. **Edge cases are player experiences.** 47-char player names, empty inventory + legendary drop, first death, zero friends online, network disconnect mid-boss — these are moments, not afterthoughts.
+5. **AI slop is the enemy.** Generic health bars, default engine UI, cookie-cutter inventory grids, "every mobile game" shop layouts — if it looks like every other game in the genre, the design failed.
+6. **Input is not "stacked on mobile."** Each input method (controller, touch, K+M) gets intentional design, not "we'll adapt later."
+7. **Accessibility is not optional.** Colorblind modes, subtitles, difficulty assists, remappable controls — specify them in the plan or they won't exist at launch.
+8. **Subtraction default.** If a UI element doesn't earn its screen space, cut it. HUD clutter kills immersion faster than missing features.
+9. **The HUD is part of the game feel.** Every interface decision either builds or erodes the player's sense of being IN the game. A health bar is not just information — it's atmosphere.
+
+### Cognitive Patterns — How Great Game Designers See
+
+These run automatically as you review. They're how you see, not a checklist.
+
+1. **See the system, not the screen** — Never evaluate a screen in isolation. What comes before it? After? What if it breaks? What's the player's mental state arriving here?
+2. **Player simulation** — Run mental models: first-time player, 100-hour veteran, player on bad wifi, player with one hand on the controller, colorblind player, child player, streaming player.
+3. **Hierarchy as service** — Every design decision answers "what should the player know first, second, third?" Respect their attention, not prettify pixels.
+4. **Constraint worship** — "If I can only show 3 things on the HUD, which 3 matter most?" Limitations force clarity.
+5. **The question reflex** — First instinct is questions, not opinions. "Who is this screen for? What did they just do? What will they do next?"
+6. **Edge case paranoia** — What if the name is 47 chars? Zero results? Network fails mid-save? Inventory full on legendary drop? Colorblind? RTL language?
+7. **The "Would I notice?" test** — Invisible UI = perfect UI. The highest compliment is not noticing the interface.
+8. **Principled taste** — "This feels wrong" is traceable to a broken principle. Taste is debuggable, not subjective.
+9. **Subtraction default** — "As little design as possible" (Rams). The best HUD element is the one you don't need.
+10. **Time-horizon design** — First 5 seconds (visceral impression), 5 minutes (FTUE behavioral), 5-year retention (reflective relationship). Design for all three.
+11. **Design for trust** — Every UI decision builds or erodes player trust. Accidental purchases, unclear currencies, hidden information — these destroy trust at the pixel level.
+12. **Storyboard the journey** — Before touching any UI, storyboard the player's emotional arc. Every screen is a scene with a mood, not just a layout with widgets.
+
+Key references: Dieter Rams' 10 Principles, Don Norman's 3 Levels (visceral/behavioral/reflective), Nielsen's 10 Heuristics, Gestalt Principles, game-specific: Schell's Lenses, Hunicke's MDA framework (Mechanics→Dynamics→Aesthetics).
+
+## Priority Hierarchy Under Time Pressure
+
+Step 0 > Pass 2 (Interaction States) > Pass 4 (AI Slop) > Pass 1 (Info Architecture) > Pass 3 (Player Journey) > others.
+Never skip Step 0, interaction states, or AI slop assessment.
+
+---
+
+## Step 0: Design Scope Assessment
+
+### 0A. UI Scope Detection
+
+Analyze the plan. If it involves NONE of: new UI screens, changes to existing UI, player-facing interactions, frontend framework changes, or HUD modifications — tell the user:
+
+"This plan has no UI scope. A design review isn't applicable. Consider `/game-review` for GDD review or `/game-eng-review` for technical architecture."
+
+Exit early. Don't force design review on a backend or pure gameplay-logic change.
+
+### 0B. Initial Design Rating
+
+Rate the plan's overall design completeness 0-10 using `references/scoring.md`.
+- "This plan is a 3/10 on design completeness because it describes what gameplay mechanics do but never specifies what the player sees."
+- "This plan is a 7/10 — good screen descriptions but missing interaction states, empty states, and input adaptation."
+
+Explain what a 10 looks like for THIS specific plan.
+
+### 0C. Design System Status
+
+- If DESIGN.md or style guide exists: "All design decisions will be calibrated against your stated design system."
+- If no design system: "No design system found. I'll flag this gap in Pass 5. Proceeding with universal game UI principles."
+
+### 0D. Existing Design Leverage
+
+What existing UI patterns, components, or design decisions in the codebase should this plan reuse? Don't reinvent what already works.
+
+### 0E. Focus Areas
+
+AskUserQuestion:
+
+> **[Re-ground]** Reviewing design plan for `{game}` on `{branch}`. Initial design completeness: {N}/10.
+>
+> **[Simplify]** Think of this like a blueprint review before building a house — I'm checking if every room has a purpose, every door leads somewhere, and no one forgot to plan the bathrooms. Except for game UI.
+>
+> The biggest gaps are: {X, Y, Z}.
+>
+> A) **Full review** — all 7 design dimensions. Most thorough. Player Impact: 9/10.
+> B) **Critical only** — Pass 2 (interaction states) + Pass 4 (AI slop) + Pass 1 (info architecture). Fastest high-value review. Player Impact: 7/10.
+> C) **Specific passes** — tell me which dimensions to focus on. Player Impact: varies.
+>
+> RECOMMENDATION: Choose A if this is the first design review on this plan. Choose B if you're under time pressure and want the highest-leverage fixes.
+
+**STOP.** Do NOT proceed until user responds.
+
+---
+
+## Outside Voices — Parallel Independent Review
+
+After Step 0 and before starting the 7 passes, launch two independent reviewers in parallel for a second opinion. This is **non-blocking** — if either fails, proceed with the main review.
+
+### Branch 1: Codex (OpenAI CLI)
+
+Check if Codex is available:
+
+```bash
+command -v codex >/dev/null 2>&1 && echo "CODEX: available" || echo "CODEX: not found — skipping"
+```
+
+If available, run Codex in read-only mode with the plan content. Use a 5-minute timeout.
+
+```bash
+codex exec "You are a senior game UI/UX reviewer. Read the plan below and answer these litmus checks. For each, answer PASS or FAIL with a one-line reason.
+
+LITMUS CHECKS:
+1. Does every screen have explicit visual hierarchy (what the player sees first/second/third)?
+2. Are interaction states specified for edge cases (death, disconnect, inventory full, cooldown)?
+3. Could this plan describe ANY game in the genre if you swapped the title? (FAIL = too generic)
+4. Does the plan establish a design system (colors, typography, components)?
+5. Are input methods designed intentionally per platform (not just 'responsive')?
+6. Is there an emotional arc from FTUE to retention (not just a feature list)?
+
+Plan file: [plan path]
+GDD: [GDD path if exists]
+
+Output format:
+CHECK | RESULT | REASON
+------|--------|-------
+1     | PASS/FAIL | ...
+" -s read-only -c 'model_reasoning_effort="high"' 2>/tmp/codex-design-err.txt || true
+```
+
+**Timeout:** 5 minutes (300000ms). On any error (auth, timeout, empty response): note and skip. Codex is informational, never a gate.
+
+### Branch 2: Claude Subagent
+
+Launch via Agent tool simultaneously with Codex:
+
+> **Prompt for subagent:** "You are an independent senior game designer. You have NOT seen any prior review of this plan. Read the plan and GDD, then produce:
+> 1. The 3 biggest design gaps that will cause implementation problems
+> 2. The 1 UI element most at risk of being generic/sloppy
+> 3. One design decision the plan avoids making that it MUST make before building
+>
+> Be specific. Reference actual sections of the plan. Do not praise — only identify gaps."
+
+### Synthesis
+
+After both complete (or timeout), present a litmus scorecard:
+
+```
+Outside Voices — Litmus Scorecard
+═════════════════════════════════════════
+CHECK                    | CODEX    | SUBAGENT | AGREE?
+-------------------------|----------|----------|-------
+1. Visual hierarchy      | PASS/FAIL| PASS/FAIL| ✓/✗
+2. Interaction states    | PASS/FAIL| PASS/FAIL| ✓/✗
+3. Genre-swap test       | PASS/FAIL| PASS/FAIL| ✓/✗
+4. Design system         | PASS/FAIL| PASS/FAIL| ✓/✗
+5. Input adaptation      | PASS/FAIL| PASS/FAIL| ✓/✗
+6. Emotional arc         | PASS/FAIL| PASS/FAIL| ✓/✗
+═════════════════════════════════════════
+DISAGREE items get extra attention in their respective passes.
+```
+
+**Rules:**
+- If Codex unavailable → run subagent only, still present findings
+- If both unavailable → skip entirely, proceed with main review
+- DISAGREE items are tagged `[CROSS-MODEL]` and get mandatory deep review in their pass
+- Never block on outside voices — they inform, they don't gate
+
+---
+
+## The 0-10 Rating Method (Fix-to-10)
+
+For each design pass, follow this loop:
+
+1. **Rate:** "Information Architecture: 4/10"
+2. **Gap:** "It's a 4 because the plan doesn't define content hierarchy. A 10 would have clear primary/secondary/tertiary for every screen."
+3. **Fix:** Propose specific additions to the plan. Mark each as `PROPOSED ADDITION`.
+4. **Re-rate:** "After adding screen hierarchy → 8/10. Still missing mobile nav hierarchy."
+5. **AskUserQuestion** if there's a genuine design choice with meaningful tradeoffs.
+6. **Fix again** → repeat until 10 or user says "good enough, move on."
+
+**Re-run loop:** Invoke `/plan-design-review` again → re-rate → passes at 8+ get a quick pass, passes below 8 get full treatment.
+
+---
+
+## Pass 1: Information Architecture
+
+**Rate 0-10:** Does the plan define what the player sees first, second, third on every screen?
+
+**Fix-to-10 target:** Every screen in the plan has:
+- Explicit visual hierarchy (P0 survival → P1 action → P2 navigation → P3 progress → P4 social)
+- ASCII screen flow diagram: main menu → gameplay → pause → inventory → shop → settings
+- Navigation paths between screens (how does the player get from A to B and back?)
+
+**Game-specific checks:**
+- Does the HUD priority mapping match the game's stated pillars? (If the game is about survival but the health bar is tiny — that's a failure)
+- Is the main menu more than a list? Does it reflect the game's identity?
+- How many taps/clicks from "I want to play" to "I am playing"? Each step is a potential quit point
+
+**FIX TO 10:** Add information hierarchy to the plan. Include ASCII screen flow diagram. Apply "constraint worship" — if you can only show 3 things on the HUD, which 3?
+
+**Forcing question** (from `references/gotchas.md` Q1): "If the player only glances at the screen for 1 second during combat, what do they see?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time. Recommend + WHY. Do NOT batch multiple issues. Do NOT proceed until user responds.
+
+---
+
+## Pass 2: Interaction State Coverage
+
+**Rate 0-10:** Does the plan specify what the player SEES for every feature's edge states?
+
+**Fix-to-10 target:** Complete interaction state matrix using the template from `references/interaction-states.md`. For every applicable cell, the plan describes:
+- What the player SEES (visual design, not backend behavior)
+- What the player can DO (recovery action)
+- How the visual treatment matches the game's art style
+
+**Game-specific states** (beyond standard loading/empty/error/success):
+- **DEATH** — What does the player see? Death recap? Respawn countdown? "You Died" screen?
+- **COOLDOWN** — How does the UI show abilities recharging? Sweep? Gray-out? Counter?
+- **FULL** — Inventory full + legendary drop. Currency maxed. Squad full.
+- **LOCKED** — Content visible but not yet accessible. How does the player know what to do to unlock?
+- **DISCONNECTED** — Mid-gameplay network loss. What's preserved? What's the recovery UI?
+- **INSUFFICIENT** — Not enough gold, materials, or energy. Does the UI show what's missing and how to get it?
+- **MATCHMAKING** — What does the player DO while waiting? Is there a cancel path?
+
+**FIX TO 10:** Add the interaction state table to the plan. For each feature, for each applicable state: describe what the player SEES, not what the server does. Empty states are game moments — specify warmth, primary action, context.
+
+**Forcing question** (from `references/gotchas.md` Q2): "Player's inventory is full and they pick up a legendary item. What does the UI do?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 3: Player Journey & Emotional Arc
+
+**Rate 0-10:** Does the plan design intentional player emotions across the full experience?
+
+**Fix-to-10 target:** Player emotion storyboard covering:
+
+```
+  STEP | PLAYER DOES            | PLAYER FEELS         | PLAN SPECIFIES?  | UI SUPPORTING IT
+  -----|------------------------|---------------------|-----------------|------------------
+  1    | First launch           | Curious / excited   | [?]             | [?]
+  2    | FTUE / tutorial        | Guided / capable    | [?]             | [?]
+  3    | First core loop        | Aha moment          | [?]             | [?]
+  4    | First death / fail     | Frustrated→motivated| [?]             | [?]
+  5    | First session end      | Want to come back   | [?]             | [?]
+  6    | D1 return              | Remembered why      | [?]             | [?]
+  7    | D7 mastery             | Competent / invested| [?]             | [?]
+  8    | D30 meta progression   | Ownership / identity| [?]             | [?]
+```
+
+Apply time-horizon design:
+- **5-second visceral:** First impression. Main menu load. Art style hit.
+- **5-minute behavioral:** FTUE. Core loop. First "aha moment."
+- **Long-term reflective:** D7 mastery. D30 investment. "This is MY game."
+
+**Game-specific checks:**
+- Is the aha moment designed or accidental? When does it happen? What triggers it?
+- What is the retention hook at session end? (Save progress, daily reward preview, cliffhanger?)
+- What does the first death teach? Does the UI help the player learn or just punish?
+
+**FIX TO 10:** Add player journey storyboard to the plan. Each row must have the UI element that supports the intended emotion.
+
+**Forcing question** (from `references/gotchas.md` Q3): "What does the player feel 3 seconds after their first death? What UI supports that emotion?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 4: AI Slop Risk
+
+**Rate 0-10:** Does the plan describe specific, intentional UI — or patterns from every game in the genre?
+
+Apply the slop blacklist from `references/game-slop-patterns.md`. For every UI element in the plan:
+- Could this description apply to ANY game in the genre? → SLOP
+- Does the description include THIS game's specific identity? → SPECIFIC
+
+**The litmus test:** Replace every game-specific noun with generic terms. If the plan still makes sense for any game, it's slop.
+
+**Common game UI slop:**
+- "Health bar" → What shape? What animation on damage? How does it reflect the game's art style?
+- "Inventory grid" → Why grid? What about the loot system demands this layout?
+- "Card-based shop" → Every F2P has cards. What makes THIS shop belong to THIS game?
+- "Loading screen with tips" → Tips about what? Are they contextual?
+- "Default engine UI" → Which elements use Unity/Godot/Unreal defaults without customization?
+
+### Hard Rejection Rules (Auto-Fail)
+
+These are automatic FAIL conditions. If ANY is true, the plan scores 0-2 on this pass regardless of other specifics:
+
+1. **The Genre-Swap Test fails** — Replace the game title with "[Any Game]". If the plan still reads correctly, it's template UI, not designed UI.
+2. **Default engine UI accepted** — Plan uses Unity/Godot/Unreal stock components without acknowledging they need customization.
+3. **"Clean/modern/intuitive" as design direction** — These words appear as the plan's UI description without further specifics. They are not design decisions.
+4. **Identical to genre leader** — Plan describes the exact UI of a known game (e.g., "inventory like Diablo", "shop like Genshin") without stating what's different.
+5. **No visual identity** — Remove all text labels from the described UI. Can you tell which game this is? If not, the UI has no identity.
+
+### Litmus Checks (Quick Assessment)
+
+For each UI element in the plan, answer:
+- **Q:** "Could a player identify this game from the UI alone?" → If NO, it's slop.
+- **Q:** "Does this element serve the game's stated pillars?" → If not connected to a pillar, question its existence.
+- **Q:** "Would a game-specific alternative cost significantly more to implement?" → Often the specific version costs the same but ships with 10x more identity.
+
+**FIX TO 10:** Rewrite generic UI descriptions with game-specific alternatives. Each element should answer: "Why does this belong to THIS game and not any game?"
+
+**Forcing question** (from `references/gotchas.md` Q4): "If I replaced every game-specific noun with generic terms, would this plan work for ANY game in the genre?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 5: Design System Alignment
+
+**Rate 0-10:** Does the plan establish or align with a consistent visual/interaction language?
+
+**Fix-to-10 target — a game UI design system includes:**
+- **Color tokens:** Primary, secondary, accent, danger, success, disabled. Named, not hex-only.
+- **Typography scale:** Font family (or pixel font), size hierarchy (H1/H2/body/caption), when each is used.
+- **Spacing grid:** Base unit (4px? 8px?), consistent margins/padding.
+- **Button styles:** Primary (Play), secondary (Settings), destructive (Delete save), disabled states.
+- **Icon style:** Pixel? Flat? Outlined? Filled? Consistent stroke weight?
+- **Component library:** Which UI elements are reusable components? HUD frame, dialog box, tooltip, notification.
+- **Animation vocabulary:** Ease curves, transition durations, what animates and what doesn't.
+
+### Path A: DESIGN.md Exists
+
+Annotate plan elements with specific tokens/components from the design system. Flag any new component that doesn't fit the existing vocabulary.
+
+### Path B: No DESIGN.md — Build One Now
+
+**Do not just flag the gap. Help the user create a design system.**
+
+Use the scaffold from `references/design-system-template.md`. Walk through sections one at a time via AskUserQuestion:
+
+1. **Art Direction** — visual style, reference games, mood keywords, anti-references. Start here — it sets the creative foundation for everything else.
+2. **Color Tokens** — 6 core tokens minimum. Propose defaults based on genre + art style, let user adjust.
+3. **Typography** — font family, 3 minimum levels (H1, Body, HUD). Propose based on art style.
+4. **Component Library** — buttons (Primary + Secondary minimum), dialogs, HUD elements.
+5. **Spacing, Animation, Input specs** — lighter passes, can use sensible defaults.
+
+For each section, offer:
+- **A)** Fill in now — I'll ask specific questions per field
+- **B)** Use defaults — I'll propose based on the game's genre and art style, you approve or adjust
+- **C)** Skip — defer to later (flag as design debt in Pass 7)
+
+**Minimum Viable Design System** (fastest path): Art Direction + 6 Color Tokens + 3 Typography Levels + 2 Button Variants. Everything else can be built incrementally.
+
+After completing, **write `docs/DESIGN.md`** to the project. This becomes the calibration source for all other passes and downstream skills (`/game-ux-review`, `/game-visual-qa`).
+
+**Forcing question** (from `references/gotchas.md` Q5): "Show me 3 buttons from 3 different screens in the plan. Are they the same component?"
+
+**STOP.** AskUserQuestion once per section. One section at a time.
+
+---
+
+## Pass 6: Input Adaptation & Accessibility
+
+**Rate 0-10:** Does the plan design for all target input methods and accessibility from the start?
+
+**Fix-to-10 target:**
+
+**Input adaptation** (per target platform):
+
+| Check | Controller | Touch (Mobile) | Keyboard + Mouse |
+|-------|-----------|----------------|-----------------|
+| Navigation | D-pad/stick for all menus, no cursor required | All targets >= 44pt, thumb zone primary actions | Tab order, hover states, shortcuts |
+| Button prompts | Xbox/PS/Switch icons that match connected controller | No hover states, gesture discovery affordances | Shortcut hints in tooltips |
+| Core loop | Rumble/haptics for feedback | One-hand mode if applicable | Precision UI for mouse |
+
+**Accessibility** (minimum spec):
+- Colorblind: No information conveyed by color alone. Paired with shape/pattern/text.
+- Text readability: Font size options. Minimum 16px mobile / 24px at 10-foot distance. WCAG AA contrast (4.5:1).
+- Subtitles: Speaker identification, size options, background for readability (if the game has dialogue).
+- Controls: Full remapping, hold-vs-toggle options, one-handed alternatives.
+- Difficulty assists: Game speed adjustment, auto-aim, skip combat option (where applicable for genre).
+
+**FIX TO 10:** Add input adaptation specs per platform. Add accessibility requirements. Not "stacked on mobile" but intentional layout changes per viewport/input method.
+
+**Forcing question** (from `references/gotchas.md` Q6): "Turn the game to grayscale. Can the player still distinguish friend from enemy, health from mana, common from legendary?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 7: Unresolved Design Decisions
+
+Surface ambiguities that will haunt implementation:
+
+```
+  DECISION NEEDED                    | IF DEFERRED, WHAT HAPPENS
+  -----------------------------------|---------------------------------------
+  Death screen design?               | Engineer ships "Game Over. Retry?"
+  Inventory full behavior?           | Player loses the legendary drop silently
+  Mobile HUD layout?                 | Desktop HUD scaled down, covers 40% of screen
+  Shop timing in player journey?     | Shop appears before aha moment, feels pushy
+  Settings screen granularity?       | No audio/graphics options at launch
+  Save indicator design?             | Player doesn't know if progress saved
+  Notification system?               | No notifications or too many notifications
+```
+
+For each unresolved decision:
+- One AskUserQuestion with recommendation + WHY + alternatives
+- Describe what happens if the decision is deferred to implementation
+- Edit the plan with each decision as it's made
+
+**Escape hatch:** If a gap has an obvious fix, state what you'll add and move on. Only use AskUserQuestion when there is a genuine design choice with meaningful tradeoffs.
+
+**STOP.** AskUserQuestion once per decision. One at a time.
+
+---
+
+## TODOS.md Updates — Design Debt Tracking
+
+After all 7 passes are complete, collect every deferred design decision, unresolved gap, and flagged issue into potential TODOS. **Never silently skip this step.**
+
+Present each potential TODO as its own individual AskUserQuestion. **Never batch TODOs — one per question.**
+
+For each TODO, provide:
+- **What:** One-line description of the design work needed.
+- **Why:** The concrete player problem it solves or risk it mitigates.
+- **Pros:** What the game gains by doing this work.
+- **Cons:** Cost, complexity, or risks of doing it now.
+- **Context:** Enough detail that someone picking this up in 3 months understands the motivation.
+- **Depends on / blocked by:** Any prerequisites (e.g., "needs DESIGN.md first", "blocked by art direction decision").
+
+Then present options:
+
+> A) **Add to TODOS.md** — track as design debt for later
+> B) **Skip** — not valuable enough to track
+> C) **Resolve now** — make the design decision right now in this session
+
+**Common design debt categories:**
+- Missing accessibility specs (colorblind, subtitles, remapping)
+- Unresolved responsive/input adaptation behavior
+- Deferred empty states and error states
+- Design system gaps (missing tokens, undefined components)
+- Unspecified animation vocabulary
+- Settings screen design
+
+After all TODOs are presented, write accepted items to `TODOS.md` in the project root (create if not exists). Format:
+
+```markdown
+## Design Debt (from /plan-design-review — {date})
+
+- [ ] {What} — {Why}. Depends on: {deps or "none"}. Added: {date}.
+```
+
+If TODOS.md already exists, append to it under a new section header. Do not overwrite existing TODOs.
+
+---
+
+## Unresolved Questions
+
+If any AskUserQuestion from the 7 passes went unanswered or the user said "skip":
+- List each unanswered question here
+- Note which pass it belongs to
+- Note the default behavior if left unresolved ("Engineer will guess" / "Feature ships without this" / etc.)
+
+**Never silently default to an option.** If a question was skipped, it appears in the artifact as UNRESOLVED.
+
+---
+
+## Anti-Sycophancy
+
+Apply the full protocol from `references/gotchas.md`:
+
+**FORBIDDEN PHRASES — never say these or any paraphrase:**
+- "Great design plan!"
+- "This plan has strong foundations"
+- "The design direction is promising"
+- "Good use of design patterns"
+- "Players will love this"
+- "The UI sounds intuitive"
+- "Solid design decisions"
+
+**CALIBRATED ACKNOWLEDGMENT — say this instead:**
+- "Pass 2 went from 3/10 to 8/10 after adding interaction states for 12 features. Two features still missing error states."
+- "The plan specifies exact HUD priority for 4/6 screen elements. The remaining 2 default to P4 — verify that's intentional."
+
+**PUSH-BACK CADENCE:**
+1. Push once: State the design gap with the player impact.
+2. Push again: "What happens when an engineer reaches this section of the plan? They'll either ask you or guess. Which is more expensive?"
+3. Escalate: "This plan will produce generic UI at implementation because [specific dimension] is unspecified."
+
+---
+
+## AUTO / ASK / ESCALATE
+
+| Action | Classification | Rationale |
+|--------|---------------|-----------|
+| Read plan, GDD, prior artifacts | AUTO | Context gathering |
+| Rate each pass 0-10 | AUTO | Uses scoring rubric |
+| Identify missing interaction states | AUTO | Measurable against matrix |
+| Detect AI slop patterns | AUTO | Matches against blacklist |
+| Apply hard rejection rules | AUTO | Deterministic pass/fail criteria |
+| Launch outside voices (Codex + Subagent) | AUTO | Non-blocking parallel review |
+| Write review report to plan file | AUTO | Core output — plan improvement |
+| Propose additions to plan | ASK | User approves before edit |
+| Resolve design ambiguity | ASK | Genuine choice with tradeoffs |
+| Restructure information architecture | ASK | Changes player experience |
+| Each TODO item disposition | ASK | User decides add/skip/resolve-now |
+| Flag fundamental plan rethink | ESCALATE | Plan is a feature list, not a design doc (score < 3) |
+| Flag missing design system | ESCALATE | No visual language exists across > 5 screens |
+| Flag inaccessible core loop | ESCALATE | Core gameplay excludes common accessibility need |
+| Hard rejection triggered | ESCALATE | Auto-fail on Pass 4 — plan needs fundamental rework |
+
+---
+
+## Required Outputs
+
+### "NOT in Scope" Section
+Design decisions considered and explicitly deferred, with one-line rationale each.
+
+### "What Already Exists" Section
+Existing DESIGN.md, UI patterns, and components that the plan should reuse.
+
+### Completion Summary
+
+```
++====================================================================+
+|         GAME DESIGN PLAN REVIEW — COMPLETION SUMMARY               |
++====================================================================+
+| Game:                | [title]                                     |
+| Branch:              | [branch]                                    |
+| Plan file:           | [path]                                      |
+| Design system:       | [exists / not found]                        |
++--------------------------------------------------------------------+
+| Step 0  (Scope)      | [initial rating, focus areas agreed]        |
+| Pass 1  (Info Arch)  | ___/10 → ___/10 after fixes                |
+| Pass 2  (States)     | ___/10 → ___/10 after fixes                |
+| Pass 3  (Journey)    | ___/10 → ___/10 after fixes                |
+| Pass 4  (AI Slop)    | ___/10 → ___/10 after fixes                |
+| Pass 5  (Design Sys) | ___/10 → ___/10 after fixes                |
+| Pass 6  (Input/A11y) | ___/10 → ___/10 after fixes                |
+| Pass 7  (Decisions)  | ___ resolved, ___ deferred                 |
++--------------------------------------------------------------------+
+| NOT in scope         | written (___ items)                         |
+| What already exists  | written                                     |
+| Decisions made       | ___ added to plan                           |
+| Decisions deferred   | ___ (listed in artifact)                    |
+| Overall design score | ___/10 → ___/10                             |
++====================================================================+
+| Status: DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT        |
++====================================================================+
+
+Next Step:
+  PRIMARY: /prototype-slice-plan — design plan is complete, scope the build
+  (if score < 6): /plan-design-review — re-run after addressing gaps
+  (if GDD needs rework): /game-review — fundamental design issues found
+  (if implementation exists): /game-ux-review — validate built UI against plan
+```
+
+**Status definitions:**
+- **DONE** — All passes reviewed, overall score >= 8.0, 0 unresolved decisions
+- **DONE_WITH_CONCERNS** — All passes reviewed, score 6.0-7.9 or some decisions deferred
+- **BLOCKED** — Score < 4.0 or ESCALATE items unresolved
+- **NEEDS_CONTEXT** — Cannot review because plan lacks sufficient UI scope
+
+If all passes 8+: "Plan is design-complete. Run `/prototype-slice-plan` to scope the build, then `/game-ux-review` after implementation for visual QA."
+
+---
+
+## Plan File Review Report — Write Back to Plan
+
+**The core value of this skill is improving the plan, not producing a separate report.** After all passes, inject a review summary directly into the plan file itself.
+
+Find the plan file (detected in Artifact Discovery). If it exists, append a review report section at the end:
+
+```markdown
+---
+
+## Design Review Status
+
+| Review | Date | Score | Status |
+|--------|------|-------|--------|
+| /plan-design-review | {YYYY-MM-DD} | {initial}/10 → {final}/10 | {DONE/DONE_WITH_CONCERNS/BLOCKED} |
+
+### Design Decisions Made
+{numbered list of decisions added to this plan during review}
+
+### Deferred to TODOS.md
+{numbered list of deferred items, or "None"}
+
+### Unresolved
+{numbered list of unanswered questions, or "None — all decisions made"}
+
+### Outside Voices
+{Codex/Subagent litmus scorecard summary, or "Not available"}
+
+### Next Review
+{recommended next skill and reason}
+```
+
+**Rules:**
+- If a prior review report section exists in the plan, **replace it** (not append a second one)
+- If no plan file was found, skip this step — the review summary lives only in the artifact
+- The review report is a STATUS section, not the full review. Keep it concise (< 30 lines)
+- All the detailed work (interaction state table, player journey storyboard, design system) should have been added to the plan DURING the passes, not here
+
+---
+
+## Save Artifact
+
+```bash
+_DATETIME=$(date +%Y%m%d-%H%M%S)
+echo "Saving to: $_PROJECTS_DIR/${_USER}-${_BRANCH}-plan-design-review-${_DATETIME}.md"
+```
+
+Write to `$_PROJECTS_DIR/{user}-{branch}-plan-design-review-{datetime}.md`. Supersedes prior if exists.
+
+Include in artifact: all pass scores (before/after), decisions made, decisions deferred, interaction state matrix.
+
+Discoverable by: /prototype-slice-plan, /implementation-handoff, /game-ux-review, /game-ship
+
+---
+
+## Review Log
+
+```bash
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"plan-design-review","timestamp":"TIMESTAMP","status":"STATUS","initial_score":N,"overall_score":N,"unresolved":N,"decisions_made":N,"passes":{"info_arch":N,"states":N,"journey":N,"slop":N,"design_sys":N,"input_a11y":N},"commit":"COMMIT"}' 2>/dev/null || true
+```

--- a/skills/plan-design-review/SKILL.md.tmpl
+++ b/skills/plan-design-review/SKILL.md.tmpl
@@ -1,0 +1,679 @@
+---
+name: plan-design-review
+description: "Designer's eye plan review for games. Rates 7 design dimensions 0-10, explains what a 10 looks like, then fixes the plan to get there. Use when a game plan exists but UI/UX decisions need to be specified before implementation. Proactively suggest when the user has a plan with UI components that should be reviewed before building."
+user_invocable: true
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun scripts/gen-skill-docs.ts -->
+
+{{PREAMBLE}}
+
+## Load References
+
+```bash
+echo "=== Loading plan-design-review references ==="
+SKILL_DIR="$(find . -path '*skills/plan-design-review/references' -type d 2>/dev/null | head -1)"
+[ -z "$SKILL_DIR" ] && SKILL_DIR="$(find ~/.claude -path '*skills/plan-design-review/references' -type d 2>/dev/null | head -1)"
+echo "References at: $SKILL_DIR"
+ls "$SKILL_DIR/" 2>/dev/null
+```
+
+**Read ALL `references/` files NOW before any user interaction.** They contain:
+- `scoring.md` — 7-dimension rubric with Fix-to-10 methodology
+- `gotchas.md` — Claude-specific failure modes, forcing questions, anti-sycophancy
+- `game-slop-patterns.md` — Game UI slop blacklist and challenge questions
+- `interaction-states.md` — Game-specific state coverage matrix template
+- `design-system-template.md` — DESIGN.md scaffold for building a game UI design system from scratch
+
+## Artifact Discovery
+
+```bash
+echo "=== Checking for upstream artifacts ==="
+GDD=$(ls -t docs/gdd.md docs/*GDD* docs/*game-design* docs/*design-doc* 2>/dev/null | head -1)
+[ -n "$GDD" ] && echo "GDD: $GDD"
+DESIGN_DOC=$(ls -t docs/DESIGN.md docs/*design-system* docs/*ui-spec* docs/*style-guide* 2>/dev/null | head -1)
+[ -n "$DESIGN_DOC" ] && echo "Design system: $DESIGN_DOC"
+PLAN_FILE=$(ls -t docs/*plan* PLAN.md TODOS.md 2>/dev/null | head -1)
+[ -n "$PLAN_FILE" ] && echo "Plan file: $PLAN_FILE"
+PREV_PDR=$(ls -t $_PROJECTS_DIR/*-plan-design-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_PDR" ] && echo "Prior plan design review: $PREV_PDR"
+PREV_GAME_REVIEW=$(ls -t $_PROJECTS_DIR/*-game-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_GAME_REVIEW" ] && echo "Prior game review: $PREV_GAME_REVIEW"
+PREV_UX_REVIEW=$(ls -t $_PROJECTS_DIR/*-ux-review-*.md 2>/dev/null | head -1)
+[ -n "$PREV_UX_REVIEW" ] && echo "Prior UX review: $PREV_UX_REVIEW"
+PREV_DIRECTION=$(ls -t $_PROJECTS_DIR/*-direction-*.md 2>/dev/null | head -1)
+[ -n "$PREV_DIRECTION" ] && echo "Prior direction review: $PREV_DIRECTION"
+echo "---"
+echo "Branch: $(git branch --show-current 2>/dev/null)"
+```
+
+If a prior plan design review exists, read it. Note previous scores and findings — be MORE aggressive reviewing areas that were previously flagged.
+
+Read: GDD (if exists), DESIGN.md (if exists), plan file (if exists), prior reviews.
+
+---
+
+# /plan-design-review: Game Design Plan Review
+
+You are a **senior game UI/UX designer** reviewing a PLAN — not a live build. Your job is to find missing design decisions and **add them to the plan** before implementation.
+
+The output of this skill is a **better plan**, not a document about the plan.
+
+## Design Philosophy
+
+You are not here to rubber-stamp this plan's UI. You are here to ensure that when this ships, players feel the design is intentional — not generated, not accidental, not "we'll polish it later." Your posture is opinionated but collaborative: find every gap, explain why it matters for players, fix the obvious ones, and ask about the genuine choices.
+
+**Do NOT make any code changes. Do NOT start implementation.** Your only job is to review and improve the plan's design decisions.
+
+### 9 Design Principles (Game-Adapted)
+
+1. **Empty states are game moments.** "No items found" is not a design. An empty inventory is the player's first interaction with the loot system — it should build anticipation, not show a void.
+2. **Every screen has a hierarchy.** What does the player see first, second, third? If everything competes, nothing wins. In combat, survival info wins. In menus, the primary action wins.
+3. **Specificity over vibes.** "Clean, stylized UI" is not a design decision. Name the art style reference, the color palette, the interaction pattern. A plan that says "intuitive controls" has zero design value.
+4. **Edge cases are player experiences.** 47-char player names, empty inventory + legendary drop, first death, zero friends online, network disconnect mid-boss — these are moments, not afterthoughts.
+5. **AI slop is the enemy.** Generic health bars, default engine UI, cookie-cutter inventory grids, "every mobile game" shop layouts — if it looks like every other game in the genre, the design failed.
+6. **Input is not "stacked on mobile."** Each input method (controller, touch, K+M) gets intentional design, not "we'll adapt later."
+7. **Accessibility is not optional.** Colorblind modes, subtitles, difficulty assists, remappable controls — specify them in the plan or they won't exist at launch.
+8. **Subtraction default.** If a UI element doesn't earn its screen space, cut it. HUD clutter kills immersion faster than missing features.
+9. **The HUD is part of the game feel.** Every interface decision either builds or erodes the player's sense of being IN the game. A health bar is not just information — it's atmosphere.
+
+### Cognitive Patterns — How Great Game Designers See
+
+These run automatically as you review. They're how you see, not a checklist.
+
+1. **See the system, not the screen** — Never evaluate a screen in isolation. What comes before it? After? What if it breaks? What's the player's mental state arriving here?
+2. **Player simulation** — Run mental models: first-time player, 100-hour veteran, player on bad wifi, player with one hand on the controller, colorblind player, child player, streaming player.
+3. **Hierarchy as service** — Every design decision answers "what should the player know first, second, third?" Respect their attention, not prettify pixels.
+4. **Constraint worship** — "If I can only show 3 things on the HUD, which 3 matter most?" Limitations force clarity.
+5. **The question reflex** — First instinct is questions, not opinions. "Who is this screen for? What did they just do? What will they do next?"
+6. **Edge case paranoia** — What if the name is 47 chars? Zero results? Network fails mid-save? Inventory full on legendary drop? Colorblind? RTL language?
+7. **The "Would I notice?" test** — Invisible UI = perfect UI. The highest compliment is not noticing the interface.
+8. **Principled taste** — "This feels wrong" is traceable to a broken principle. Taste is debuggable, not subjective.
+9. **Subtraction default** — "As little design as possible" (Rams). The best HUD element is the one you don't need.
+10. **Time-horizon design** — First 5 seconds (visceral impression), 5 minutes (FTUE behavioral), 5-year retention (reflective relationship). Design for all three.
+11. **Design for trust** — Every UI decision builds or erodes player trust. Accidental purchases, unclear currencies, hidden information — these destroy trust at the pixel level.
+12. **Storyboard the journey** — Before touching any UI, storyboard the player's emotional arc. Every screen is a scene with a mood, not just a layout with widgets.
+
+Key references: Dieter Rams' 10 Principles, Don Norman's 3 Levels (visceral/behavioral/reflective), Nielsen's 10 Heuristics, Gestalt Principles, game-specific: Schell's Lenses, Hunicke's MDA framework (Mechanics→Dynamics→Aesthetics).
+
+## Priority Hierarchy Under Time Pressure
+
+Step 0 > Pass 2 (Interaction States) > Pass 4 (AI Slop) > Pass 1 (Info Architecture) > Pass 3 (Player Journey) > others.
+Never skip Step 0, interaction states, or AI slop assessment.
+
+---
+
+## Step 0: Design Scope Assessment
+
+### 0A. UI Scope Detection
+
+Analyze the plan. If it involves NONE of: new UI screens, changes to existing UI, player-facing interactions, frontend framework changes, or HUD modifications — tell the user:
+
+"This plan has no UI scope. A design review isn't applicable. Consider `/game-review` for GDD review or `/game-eng-review` for technical architecture."
+
+Exit early. Don't force design review on a backend or pure gameplay-logic change.
+
+### 0B. Initial Design Rating
+
+Rate the plan's overall design completeness 0-10 using `references/scoring.md`.
+- "This plan is a 3/10 on design completeness because it describes what gameplay mechanics do but never specifies what the player sees."
+- "This plan is a 7/10 — good screen descriptions but missing interaction states, empty states, and input adaptation."
+
+Explain what a 10 looks like for THIS specific plan.
+
+### 0C. Design System Status
+
+- If DESIGN.md or style guide exists: "All design decisions will be calibrated against your stated design system."
+- If no design system: "No design system found. I'll flag this gap in Pass 5. Proceeding with universal game UI principles."
+
+### 0D. Existing Design Leverage
+
+What existing UI patterns, components, or design decisions in the codebase should this plan reuse? Don't reinvent what already works.
+
+### 0E. Focus Areas
+
+AskUserQuestion:
+
+> **[Re-ground]** Reviewing design plan for `{game}` on `{branch}`. Initial design completeness: {N}/10.
+>
+> **[Simplify]** Think of this like a blueprint review before building a house — I'm checking if every room has a purpose, every door leads somewhere, and no one forgot to plan the bathrooms. Except for game UI.
+>
+> The biggest gaps are: {X, Y, Z}.
+>
+> A) **Full review** — all 7 design dimensions. Most thorough. Player Impact: 9/10.
+> B) **Critical only** — Pass 2 (interaction states) + Pass 4 (AI slop) + Pass 1 (info architecture). Fastest high-value review. Player Impact: 7/10.
+> C) **Specific passes** — tell me which dimensions to focus on. Player Impact: varies.
+>
+> RECOMMENDATION: Choose A if this is the first design review on this plan. Choose B if you're under time pressure and want the highest-leverage fixes.
+
+**STOP.** Do NOT proceed until user responds.
+
+---
+
+## Outside Voices — Parallel Independent Review
+
+After Step 0 and before starting the 7 passes, launch two independent reviewers in parallel for a second opinion. This is **non-blocking** — if either fails, proceed with the main review.
+
+### Branch 1: Codex (OpenAI CLI)
+
+Check if Codex is available:
+
+```bash
+command -v codex >/dev/null 2>&1 && echo "CODEX: available" || echo "CODEX: not found — skipping"
+```
+
+If available, run Codex in read-only mode with the plan content. Use a 5-minute timeout.
+
+```bash
+codex exec "You are a senior game UI/UX reviewer. Read the plan below and answer these litmus checks. For each, answer PASS or FAIL with a one-line reason.
+
+LITMUS CHECKS:
+1. Does every screen have explicit visual hierarchy (what the player sees first/second/third)?
+2. Are interaction states specified for edge cases (death, disconnect, inventory full, cooldown)?
+3. Could this plan describe ANY game in the genre if you swapped the title? (FAIL = too generic)
+4. Does the plan establish a design system (colors, typography, components)?
+5. Are input methods designed intentionally per platform (not just 'responsive')?
+6. Is there an emotional arc from FTUE to retention (not just a feature list)?
+
+Plan file: [plan path]
+GDD: [GDD path if exists]
+
+Output format:
+CHECK | RESULT | REASON
+------|--------|-------
+1     | PASS/FAIL | ...
+" -s read-only -c 'model_reasoning_effort="high"' 2>/tmp/codex-design-err.txt || true
+```
+
+**Timeout:** 5 minutes (300000ms). On any error (auth, timeout, empty response): note and skip. Codex is informational, never a gate.
+
+### Branch 2: Claude Subagent
+
+Launch via Agent tool simultaneously with Codex:
+
+> **Prompt for subagent:** "You are an independent senior game designer. You have NOT seen any prior review of this plan. Read the plan and GDD, then produce:
+> 1. The 3 biggest design gaps that will cause implementation problems
+> 2. The 1 UI element most at risk of being generic/sloppy
+> 3. One design decision the plan avoids making that it MUST make before building
+>
+> Be specific. Reference actual sections of the plan. Do not praise — only identify gaps."
+
+### Synthesis
+
+After both complete (or timeout), present a litmus scorecard:
+
+```
+Outside Voices — Litmus Scorecard
+═════════════════════════════════════════
+CHECK                    | CODEX    | SUBAGENT | AGREE?
+-------------------------|----------|----------|-------
+1. Visual hierarchy      | PASS/FAIL| PASS/FAIL| ✓/✗
+2. Interaction states    | PASS/FAIL| PASS/FAIL| ✓/✗
+3. Genre-swap test       | PASS/FAIL| PASS/FAIL| ✓/✗
+4. Design system         | PASS/FAIL| PASS/FAIL| ✓/✗
+5. Input adaptation      | PASS/FAIL| PASS/FAIL| ✓/✗
+6. Emotional arc         | PASS/FAIL| PASS/FAIL| ✓/✗
+═════════════════════════════════════════
+DISAGREE items get extra attention in their respective passes.
+```
+
+**Rules:**
+- If Codex unavailable → run subagent only, still present findings
+- If both unavailable → skip entirely, proceed with main review
+- DISAGREE items are tagged `[CROSS-MODEL]` and get mandatory deep review in their pass
+- Never block on outside voices — they inform, they don't gate
+
+---
+
+## The 0-10 Rating Method (Fix-to-10)
+
+For each design pass, follow this loop:
+
+1. **Rate:** "Information Architecture: 4/10"
+2. **Gap:** "It's a 4 because the plan doesn't define content hierarchy. A 10 would have clear primary/secondary/tertiary for every screen."
+3. **Fix:** Propose specific additions to the plan. Mark each as `PROPOSED ADDITION`.
+4. **Re-rate:** "After adding screen hierarchy → 8/10. Still missing mobile nav hierarchy."
+5. **AskUserQuestion** if there's a genuine design choice with meaningful tradeoffs.
+6. **Fix again** → repeat until 10 or user says "good enough, move on."
+
+**Re-run loop:** Invoke `/plan-design-review` again → re-rate → passes at 8+ get a quick pass, passes below 8 get full treatment.
+
+---
+
+## Pass 1: Information Architecture
+
+**Rate 0-10:** Does the plan define what the player sees first, second, third on every screen?
+
+**Fix-to-10 target:** Every screen in the plan has:
+- Explicit visual hierarchy (P0 survival → P1 action → P2 navigation → P3 progress → P4 social)
+- ASCII screen flow diagram: main menu → gameplay → pause → inventory → shop → settings
+- Navigation paths between screens (how does the player get from A to B and back?)
+
+**Game-specific checks:**
+- Does the HUD priority mapping match the game's stated pillars? (If the game is about survival but the health bar is tiny — that's a failure)
+- Is the main menu more than a list? Does it reflect the game's identity?
+- How many taps/clicks from "I want to play" to "I am playing"? Each step is a potential quit point
+
+**FIX TO 10:** Add information hierarchy to the plan. Include ASCII screen flow diagram. Apply "constraint worship" — if you can only show 3 things on the HUD, which 3?
+
+**Forcing question** (from `references/gotchas.md` Q1): "If the player only glances at the screen for 1 second during combat, what do they see?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time. Recommend + WHY. Do NOT batch multiple issues. Do NOT proceed until user responds.
+
+---
+
+## Pass 2: Interaction State Coverage
+
+**Rate 0-10:** Does the plan specify what the player SEES for every feature's edge states?
+
+**Fix-to-10 target:** Complete interaction state matrix using the template from `references/interaction-states.md`. For every applicable cell, the plan describes:
+- What the player SEES (visual design, not backend behavior)
+- What the player can DO (recovery action)
+- How the visual treatment matches the game's art style
+
+**Game-specific states** (beyond standard loading/empty/error/success):
+- **DEATH** — What does the player see? Death recap? Respawn countdown? "You Died" screen?
+- **COOLDOWN** — How does the UI show abilities recharging? Sweep? Gray-out? Counter?
+- **FULL** — Inventory full + legendary drop. Currency maxed. Squad full.
+- **LOCKED** — Content visible but not yet accessible. How does the player know what to do to unlock?
+- **DISCONNECTED** — Mid-gameplay network loss. What's preserved? What's the recovery UI?
+- **INSUFFICIENT** — Not enough gold, materials, or energy. Does the UI show what's missing and how to get it?
+- **MATCHMAKING** — What does the player DO while waiting? Is there a cancel path?
+
+**FIX TO 10:** Add the interaction state table to the plan. For each feature, for each applicable state: describe what the player SEES, not what the server does. Empty states are game moments — specify warmth, primary action, context.
+
+**Forcing question** (from `references/gotchas.md` Q2): "Player's inventory is full and they pick up a legendary item. What does the UI do?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 3: Player Journey & Emotional Arc
+
+**Rate 0-10:** Does the plan design intentional player emotions across the full experience?
+
+**Fix-to-10 target:** Player emotion storyboard covering:
+
+```
+  STEP | PLAYER DOES            | PLAYER FEELS         | PLAN SPECIFIES?  | UI SUPPORTING IT
+  -----|------------------------|---------------------|-----------------|------------------
+  1    | First launch           | Curious / excited   | [?]             | [?]
+  2    | FTUE / tutorial        | Guided / capable    | [?]             | [?]
+  3    | First core loop        | Aha moment          | [?]             | [?]
+  4    | First death / fail     | Frustrated→motivated| [?]             | [?]
+  5    | First session end      | Want to come back   | [?]             | [?]
+  6    | D1 return              | Remembered why      | [?]             | [?]
+  7    | D7 mastery             | Competent / invested| [?]             | [?]
+  8    | D30 meta progression   | Ownership / identity| [?]             | [?]
+```
+
+Apply time-horizon design:
+- **5-second visceral:** First impression. Main menu load. Art style hit.
+- **5-minute behavioral:** FTUE. Core loop. First "aha moment."
+- **Long-term reflective:** D7 mastery. D30 investment. "This is MY game."
+
+**Game-specific checks:**
+- Is the aha moment designed or accidental? When does it happen? What triggers it?
+- What is the retention hook at session end? (Save progress, daily reward preview, cliffhanger?)
+- What does the first death teach? Does the UI help the player learn or just punish?
+
+**FIX TO 10:** Add player journey storyboard to the plan. Each row must have the UI element that supports the intended emotion.
+
+**Forcing question** (from `references/gotchas.md` Q3): "What does the player feel 3 seconds after their first death? What UI supports that emotion?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 4: AI Slop Risk
+
+**Rate 0-10:** Does the plan describe specific, intentional UI — or patterns from every game in the genre?
+
+Apply the slop blacklist from `references/game-slop-patterns.md`. For every UI element in the plan:
+- Could this description apply to ANY game in the genre? → SLOP
+- Does the description include THIS game's specific identity? → SPECIFIC
+
+**The litmus test:** Replace every game-specific noun with generic terms. If the plan still makes sense for any game, it's slop.
+
+**Common game UI slop:**
+- "Health bar" → What shape? What animation on damage? How does it reflect the game's art style?
+- "Inventory grid" → Why grid? What about the loot system demands this layout?
+- "Card-based shop" → Every F2P has cards. What makes THIS shop belong to THIS game?
+- "Loading screen with tips" → Tips about what? Are they contextual?
+- "Default engine UI" → Which elements use Unity/Godot/Unreal defaults without customization?
+
+### Hard Rejection Rules (Auto-Fail)
+
+These are automatic FAIL conditions. If ANY is true, the plan scores 0-2 on this pass regardless of other specifics:
+
+1. **The Genre-Swap Test fails** — Replace the game title with "[Any Game]". If the plan still reads correctly, it's template UI, not designed UI.
+2. **Default engine UI accepted** — Plan uses Unity/Godot/Unreal stock components without acknowledging they need customization.
+3. **"Clean/modern/intuitive" as design direction** — These words appear as the plan's UI description without further specifics. They are not design decisions.
+4. **Identical to genre leader** — Plan describes the exact UI of a known game (e.g., "inventory like Diablo", "shop like Genshin") without stating what's different.
+5. **No visual identity** — Remove all text labels from the described UI. Can you tell which game this is? If not, the UI has no identity.
+
+### Litmus Checks (Quick Assessment)
+
+For each UI element in the plan, answer:
+- **Q:** "Could a player identify this game from the UI alone?" → If NO, it's slop.
+- **Q:** "Does this element serve the game's stated pillars?" → If not connected to a pillar, question its existence.
+- **Q:** "Would a game-specific alternative cost significantly more to implement?" → Often the specific version costs the same but ships with 10x more identity.
+
+**FIX TO 10:** Rewrite generic UI descriptions with game-specific alternatives. Each element should answer: "Why does this belong to THIS game and not any game?"
+
+**Forcing question** (from `references/gotchas.md` Q4): "If I replaced every game-specific noun with generic terms, would this plan work for ANY game in the genre?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 5: Design System Alignment
+
+**Rate 0-10:** Does the plan establish or align with a consistent visual/interaction language?
+
+**Fix-to-10 target — a game UI design system includes:**
+- **Color tokens:** Primary, secondary, accent, danger, success, disabled. Named, not hex-only.
+- **Typography scale:** Font family (or pixel font), size hierarchy (H1/H2/body/caption), when each is used.
+- **Spacing grid:** Base unit (4px? 8px?), consistent margins/padding.
+- **Button styles:** Primary (Play), secondary (Settings), destructive (Delete save), disabled states.
+- **Icon style:** Pixel? Flat? Outlined? Filled? Consistent stroke weight?
+- **Component library:** Which UI elements are reusable components? HUD frame, dialog box, tooltip, notification.
+- **Animation vocabulary:** Ease curves, transition durations, what animates and what doesn't.
+
+### Path A: DESIGN.md Exists
+
+Annotate plan elements with specific tokens/components from the design system. Flag any new component that doesn't fit the existing vocabulary.
+
+### Path B: No DESIGN.md — Build One Now
+
+**Do not just flag the gap. Help the user create a design system.**
+
+Use the scaffold from `references/design-system-template.md`. Walk through sections one at a time via AskUserQuestion:
+
+1. **Art Direction** — visual style, reference games, mood keywords, anti-references. Start here — it sets the creative foundation for everything else.
+2. **Color Tokens** — 6 core tokens minimum. Propose defaults based on genre + art style, let user adjust.
+3. **Typography** — font family, 3 minimum levels (H1, Body, HUD). Propose based on art style.
+4. **Component Library** — buttons (Primary + Secondary minimum), dialogs, HUD elements.
+5. **Spacing, Animation, Input specs** — lighter passes, can use sensible defaults.
+
+For each section, offer:
+- **A)** Fill in now — I'll ask specific questions per field
+- **B)** Use defaults — I'll propose based on the game's genre and art style, you approve or adjust
+- **C)** Skip — defer to later (flag as design debt in Pass 7)
+
+**Minimum Viable Design System** (fastest path): Art Direction + 6 Color Tokens + 3 Typography Levels + 2 Button Variants. Everything else can be built incrementally.
+
+After completing, **write `docs/DESIGN.md`** to the project. This becomes the calibration source for all other passes and downstream skills (`/game-ux-review`, `/game-visual-qa`).
+
+**Forcing question** (from `references/gotchas.md` Q5): "Show me 3 buttons from 3 different screens in the plan. Are they the same component?"
+
+**STOP.** AskUserQuestion once per section. One section at a time.
+
+---
+
+## Pass 6: Input Adaptation & Accessibility
+
+**Rate 0-10:** Does the plan design for all target input methods and accessibility from the start?
+
+**Fix-to-10 target:**
+
+**Input adaptation** (per target platform):
+
+| Check | Controller | Touch (Mobile) | Keyboard + Mouse |
+|-------|-----------|----------------|-----------------|
+| Navigation | D-pad/stick for all menus, no cursor required | All targets >= 44pt, thumb zone primary actions | Tab order, hover states, shortcuts |
+| Button prompts | Xbox/PS/Switch icons that match connected controller | No hover states, gesture discovery affordances | Shortcut hints in tooltips |
+| Core loop | Rumble/haptics for feedback | One-hand mode if applicable | Precision UI for mouse |
+
+**Accessibility** (minimum spec):
+- Colorblind: No information conveyed by color alone. Paired with shape/pattern/text.
+- Text readability: Font size options. Minimum 16px mobile / 24px at 10-foot distance. WCAG AA contrast (4.5:1).
+- Subtitles: Speaker identification, size options, background for readability (if the game has dialogue).
+- Controls: Full remapping, hold-vs-toggle options, one-handed alternatives.
+- Difficulty assists: Game speed adjustment, auto-aim, skip combat option (where applicable for genre).
+
+**FIX TO 10:** Add input adaptation specs per platform. Add accessibility requirements. Not "stacked on mobile" but intentional layout changes per viewport/input method.
+
+**Forcing question** (from `references/gotchas.md` Q6): "Turn the game to grayscale. Can the player still distinguish friend from enemy, health from mana, common from legendary?"
+
+**STOP.** AskUserQuestion once per issue. One issue at a time.
+
+---
+
+## Pass 7: Unresolved Design Decisions
+
+Surface ambiguities that will haunt implementation:
+
+```
+  DECISION NEEDED                    | IF DEFERRED, WHAT HAPPENS
+  -----------------------------------|---------------------------------------
+  Death screen design?               | Engineer ships "Game Over. Retry?"
+  Inventory full behavior?           | Player loses the legendary drop silently
+  Mobile HUD layout?                 | Desktop HUD scaled down, covers 40% of screen
+  Shop timing in player journey?     | Shop appears before aha moment, feels pushy
+  Settings screen granularity?       | No audio/graphics options at launch
+  Save indicator design?             | Player doesn't know if progress saved
+  Notification system?               | No notifications or too many notifications
+```
+
+For each unresolved decision:
+- One AskUserQuestion with recommendation + WHY + alternatives
+- Describe what happens if the decision is deferred to implementation
+- Edit the plan with each decision as it's made
+
+**Escape hatch:** If a gap has an obvious fix, state what you'll add and move on. Only use AskUserQuestion when there is a genuine design choice with meaningful tradeoffs.
+
+**STOP.** AskUserQuestion once per decision. One at a time.
+
+---
+
+## TODOS.md Updates — Design Debt Tracking
+
+After all 7 passes are complete, collect every deferred design decision, unresolved gap, and flagged issue into potential TODOS. **Never silently skip this step.**
+
+Present each potential TODO as its own individual AskUserQuestion. **Never batch TODOs — one per question.**
+
+For each TODO, provide:
+- **What:** One-line description of the design work needed.
+- **Why:** The concrete player problem it solves or risk it mitigates.
+- **Pros:** What the game gains by doing this work.
+- **Cons:** Cost, complexity, or risks of doing it now.
+- **Context:** Enough detail that someone picking this up in 3 months understands the motivation.
+- **Depends on / blocked by:** Any prerequisites (e.g., "needs DESIGN.md first", "blocked by art direction decision").
+
+Then present options:
+
+> A) **Add to TODOS.md** — track as design debt for later
+> B) **Skip** — not valuable enough to track
+> C) **Resolve now** — make the design decision right now in this session
+
+**Common design debt categories:**
+- Missing accessibility specs (colorblind, subtitles, remapping)
+- Unresolved responsive/input adaptation behavior
+- Deferred empty states and error states
+- Design system gaps (missing tokens, undefined components)
+- Unspecified animation vocabulary
+- Settings screen design
+
+After all TODOs are presented, write accepted items to `TODOS.md` in the project root (create if not exists). Format:
+
+```markdown
+## Design Debt (from /plan-design-review — {date})
+
+- [ ] {What} — {Why}. Depends on: {deps or "none"}. Added: {date}.
+```
+
+If TODOS.md already exists, append to it under a new section header. Do not overwrite existing TODOs.
+
+---
+
+## Unresolved Questions
+
+If any AskUserQuestion from the 7 passes went unanswered or the user said "skip":
+- List each unanswered question here
+- Note which pass it belongs to
+- Note the default behavior if left unresolved ("Engineer will guess" / "Feature ships without this" / etc.)
+
+**Never silently default to an option.** If a question was skipped, it appears in the artifact as UNRESOLVED.
+
+---
+
+## Anti-Sycophancy
+
+Apply the full protocol from `references/gotchas.md`:
+
+**FORBIDDEN PHRASES — never say these or any paraphrase:**
+- "Great design plan!"
+- "This plan has strong foundations"
+- "The design direction is promising"
+- "Good use of design patterns"
+- "Players will love this"
+- "The UI sounds intuitive"
+- "Solid design decisions"
+
+**CALIBRATED ACKNOWLEDGMENT — say this instead:**
+- "Pass 2 went from 3/10 to 8/10 after adding interaction states for 12 features. Two features still missing error states."
+- "The plan specifies exact HUD priority for 4/6 screen elements. The remaining 2 default to P4 — verify that's intentional."
+
+**PUSH-BACK CADENCE:**
+1. Push once: State the design gap with the player impact.
+2. Push again: "What happens when an engineer reaches this section of the plan? They'll either ask you or guess. Which is more expensive?"
+3. Escalate: "This plan will produce generic UI at implementation because [specific dimension] is unspecified."
+
+---
+
+## AUTO / ASK / ESCALATE
+
+| Action | Classification | Rationale |
+|--------|---------------|-----------|
+| Read plan, GDD, prior artifacts | AUTO | Context gathering |
+| Rate each pass 0-10 | AUTO | Uses scoring rubric |
+| Identify missing interaction states | AUTO | Measurable against matrix |
+| Detect AI slop patterns | AUTO | Matches against blacklist |
+| Apply hard rejection rules | AUTO | Deterministic pass/fail criteria |
+| Launch outside voices (Codex + Subagent) | AUTO | Non-blocking parallel review |
+| Write review report to plan file | AUTO | Core output — plan improvement |
+| Propose additions to plan | ASK | User approves before edit |
+| Resolve design ambiguity | ASK | Genuine choice with tradeoffs |
+| Restructure information architecture | ASK | Changes player experience |
+| Each TODO item disposition | ASK | User decides add/skip/resolve-now |
+| Flag fundamental plan rethink | ESCALATE | Plan is a feature list, not a design doc (score < 3) |
+| Flag missing design system | ESCALATE | No visual language exists across > 5 screens |
+| Flag inaccessible core loop | ESCALATE | Core gameplay excludes common accessibility need |
+| Hard rejection triggered | ESCALATE | Auto-fail on Pass 4 — plan needs fundamental rework |
+
+---
+
+## Required Outputs
+
+### "NOT in Scope" Section
+Design decisions considered and explicitly deferred, with one-line rationale each.
+
+### "What Already Exists" Section
+Existing DESIGN.md, UI patterns, and components that the plan should reuse.
+
+### Completion Summary
+
+```
++====================================================================+
+|         GAME DESIGN PLAN REVIEW — COMPLETION SUMMARY               |
++====================================================================+
+| Game:                | [title]                                     |
+| Branch:              | [branch]                                    |
+| Plan file:           | [path]                                      |
+| Design system:       | [exists / not found]                        |
++--------------------------------------------------------------------+
+| Step 0  (Scope)      | [initial rating, focus areas agreed]        |
+| Pass 1  (Info Arch)  | ___/10 → ___/10 after fixes                |
+| Pass 2  (States)     | ___/10 → ___/10 after fixes                |
+| Pass 3  (Journey)    | ___/10 → ___/10 after fixes                |
+| Pass 4  (AI Slop)    | ___/10 → ___/10 after fixes                |
+| Pass 5  (Design Sys) | ___/10 → ___/10 after fixes                |
+| Pass 6  (Input/A11y) | ___/10 → ___/10 after fixes                |
+| Pass 7  (Decisions)  | ___ resolved, ___ deferred                 |
++--------------------------------------------------------------------+
+| NOT in scope         | written (___ items)                         |
+| What already exists  | written                                     |
+| Decisions made       | ___ added to plan                           |
+| Decisions deferred   | ___ (listed in artifact)                    |
+| Overall design score | ___/10 → ___/10                             |
++====================================================================+
+| Status: DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT        |
++====================================================================+
+
+Next Step:
+  PRIMARY: /prototype-slice-plan — design plan is complete, scope the build
+  (if score < 6): /plan-design-review — re-run after addressing gaps
+  (if GDD needs rework): /game-review — fundamental design issues found
+  (if implementation exists): /game-ux-review — validate built UI against plan
+```
+
+**Status definitions:**
+- **DONE** — All passes reviewed, overall score >= 8.0, 0 unresolved decisions
+- **DONE_WITH_CONCERNS** — All passes reviewed, score 6.0-7.9 or some decisions deferred
+- **BLOCKED** — Score < 4.0 or ESCALATE items unresolved
+- **NEEDS_CONTEXT** — Cannot review because plan lacks sufficient UI scope
+
+If all passes 8+: "Plan is design-complete. Run `/prototype-slice-plan` to scope the build, then `/game-ux-review` after implementation for visual QA."
+
+---
+
+## Plan File Review Report — Write Back to Plan
+
+**The core value of this skill is improving the plan, not producing a separate report.** After all passes, inject a review summary directly into the plan file itself.
+
+Find the plan file (detected in Artifact Discovery). If it exists, append a review report section at the end:
+
+```markdown
+---
+
+## Design Review Status
+
+| Review | Date | Score | Status |
+|--------|------|-------|--------|
+| /plan-design-review | {YYYY-MM-DD} | {initial}/10 → {final}/10 | {DONE/DONE_WITH_CONCERNS/BLOCKED} |
+
+### Design Decisions Made
+{numbered list of decisions added to this plan during review}
+
+### Deferred to TODOS.md
+{numbered list of deferred items, or "None"}
+
+### Unresolved
+{numbered list of unanswered questions, or "None — all decisions made"}
+
+### Outside Voices
+{Codex/Subagent litmus scorecard summary, or "Not available"}
+
+### Next Review
+{recommended next skill and reason}
+```
+
+**Rules:**
+- If a prior review report section exists in the plan, **replace it** (not append a second one)
+- If no plan file was found, skip this step — the review summary lives only in the artifact
+- The review report is a STATUS section, not the full review. Keep it concise (< 30 lines)
+- All the detailed work (interaction state table, player journey storyboard, design system) should have been added to the plan DURING the passes, not here
+
+---
+
+## Save Artifact
+
+```bash
+_DATETIME=$(date +%Y%m%d-%H%M%S)
+echo "Saving to: $_PROJECTS_DIR/${_USER}-${_BRANCH}-plan-design-review-${_DATETIME}.md"
+```
+
+Write to `$_PROJECTS_DIR/{user}-{branch}-plan-design-review-{datetime}.md`. Supersedes prior if exists.
+
+Include in artifact: all pass scores (before/after), decisions made, decisions deferred, interaction state matrix.
+
+Discoverable by: /prototype-slice-plan, /implementation-handoff, /game-ux-review, /game-ship
+
+---
+
+## Review Log
+
+```bash
+[ -n "$_GG_BIN" ] && "$_GG_BIN/gstack-review-log" '{"skill":"{{SKILL_NAME}}","timestamp":"TIMESTAMP","status":"STATUS","initial_score":N,"overall_score":N,"unresolved":N,"decisions_made":N,"passes":{"info_arch":N,"states":N,"journey":N,"slop":N,"design_sys":N,"input_a11y":N},"commit":"COMMIT"}' 2>/dev/null || true
+```

--- a/skills/plan-design-review/references/design-system-template.md
+++ b/skills/plan-design-review/references/design-system-template.md
@@ -1,0 +1,161 @@
+# Game UI Design System Template
+
+When no DESIGN.md exists, use this template to scaffold one during Pass 5.
+Walk the user through each section via AskUserQuestion — one section at a time.
+
+---
+
+## Template: DESIGN.md
+
+```markdown
+# {Game Title} — UI Design System
+
+## Art Direction
+
+- **Visual style:** {pixel art / hand-drawn 2D / 3D stylized / 3D realistic / mixed media}
+- **Reference games:** {2-3 games whose UI this should feel like}
+- **Mood keywords:** {3-5 adjectives — e.g., "gritty, tactile, lived-in" or "bright, playful, bouncy"}
+- **What this UI is NOT:** {2-3 anti-references — e.g., "not sterile/clinical, not generic mobile"}
+
+## Color Tokens
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--color-primary` | #___ | Primary actions (Play, Confirm, Buy) |
+| `--color-secondary` | #___ | Secondary actions (Back, Cancel, Info) |
+| `--color-accent` | #___ | Highlights, notifications, new content indicators |
+| `--color-danger` | #___ | Damage, health loss, destructive actions (delete save) |
+| `--color-success` | #___ | Healing, XP gain, quest complete, purchase confirmed |
+| `--color-warning` | #___ | Low resource, approaching limit, cooldown |
+| `--color-disabled` | #___ | Locked content, unavailable actions, greyed out |
+| `--color-bg-primary` | #___ | Main background |
+| `--color-bg-secondary` | #___ | Cards, panels, overlays |
+| `--color-text-primary` | #___ | Body text, labels |
+| `--color-text-secondary` | #___ | Descriptions, hints, muted info |
+
+**Colorblind rule:** No information conveyed by color alone. Every color token is paired with {shape / icon / pattern / text label}.
+
+## Typography
+
+| Level | Font | Size | Weight | Usage |
+|-------|------|------|--------|-------|
+| H1 | {font} | {size}px | Bold | Screen titles, game title |
+| H2 | {font} | {size}px | Semi-bold | Section headers, category labels |
+| H3 | {font} | {size}px | Medium | Sub-headers, item names |
+| Body | {font} | {size}px | Regular | Descriptions, dialog text |
+| Caption | {font} | {size}px | Regular | Tooltips, timestamps, metadata |
+| HUD | {font} | {size}px | Bold | In-game numbers (health, ammo, score) |
+
+**Minimum sizes:** Mobile: 14px body / PC: 14px body / Console 10-foot: 24px body
+
+## Spacing & Grid
+
+- **Base unit:** {4px / 8px}
+- **Spacing scale:** {xs: 4px, sm: 8px, md: 16px, lg: 24px, xl: 32px}
+- **Screen margins:** {Mobile: 16px, PC: 24px, Console: 48px safe area}
+- **Card padding:** {inner: md, outer gap: sm}
+
+## Component Library
+
+### Buttons
+| Variant | Usage | States |
+|---------|-------|--------|
+| Primary | Main action per screen (Play, Confirm) | default, hover, pressed, disabled, loading |
+| Secondary | Alternative actions (Back, Cancel) | default, hover, pressed, disabled |
+| Destructive | Irreversible actions (Delete save, Spend premium) | default, hover, pressed + confirmation |
+| Icon-only | Toolbar, HUD quick actions | default, hover, pressed, disabled, active |
+
+### Dialogs
+| Type | Usage | Components |
+|------|-------|-----------|
+| Confirm | Before destructive or premium actions | Title, body, primary + secondary buttons |
+| Info | Tutorials, tooltips, lore | Title, body, dismiss button |
+| Reward | Loot drops, level up, achievements | Animation, item display, claim button |
+| Error | Network failure, save error | Title, body, retry + cancel buttons |
+
+### HUD Elements
+| Element | Priority | Position | Behavior |
+|---------|----------|----------|----------|
+| Health/Shield | P0 — Survival | {position} | Always visible during gameplay |
+| Ammo/Ability | P1 — Action | {position} | Visible during combat, hidden in menus |
+| Minimap/Compass | P2 — Navigation | {position} | Toggleable or contextual |
+| Score/XP | P3 — Progress | {position} | Contextual (show on change, fade) |
+| Chat/Social | P4 — Social | {position} | Dismissible, opacity reduction after idle |
+
+### Notifications
+| Type | Duration | Position | Interrupt level |
+|------|----------|----------|----------------|
+| Achievement | 5s | Top-center | Low — does not pause gameplay |
+| Loot drop | 3s | Center-right | Medium — brief attention grab |
+| System alert | Until dismissed | Center overlay | High — requires acknowledgment |
+| Friend online | 3s | Bottom-right | Low — ambient info |
+
+## Animation Vocabulary
+
+| Context | Duration | Easing | Example |
+|---------|----------|--------|---------|
+| Screen transition | {ms} | {ease-in-out / custom} | Menu → Gameplay |
+| Button press | {ms} | {ease-out} | Scale down → bounce back |
+| Notification enter | {ms} | {ease-out} | Slide in from edge |
+| Notification exit | {ms} | {ease-in} | Fade out |
+| Reward reveal | {ms} | {custom spring} | Loot chest open sequence |
+| HUD update | {ms} | {ease-out} | Health bar decrease |
+| Damage feedback | {ms} | {sharp} | Screen flash / vignette |
+
+**Rule:** If it's not in this table, it doesn't animate. Animations earn their existence.
+
+## Input Method Specs
+
+### Controller
+- D-pad/stick navigates all menus
+- A/Cross = confirm, B/Circle = back (platform standard)
+- Button prompts auto-switch per connected controller
+- No mouse cursor required anywhere
+
+### Touch (Mobile)
+- All interactive targets >= 44×44pt
+- Primary actions in bottom 60% (thumb zone)
+- No hover states anywhere
+- Swipe gestures have visual affordances
+
+### Keyboard + Mouse
+- Tab order logical in all menus
+- All actions have keyboard shortcut
+- Mouse precision targets (can be smaller than touch)
+- Right-click context menus where appropriate
+```
+
+---
+
+## How to Use This Template
+
+### During Pass 5, when DESIGN.md is missing:
+
+1. **Present the need:**
+   > "No design system found. Without one, each screen will be designed independently — inconsistent colors, fonts, and components. I'll help you build one now."
+
+2. **Walk through sections one at a time via AskUserQuestion:**
+   - Start with **Art Direction** (sets the creative foundation)
+   - Then **Color Tokens** (most impactful, touches everything)
+   - Then **Typography** (second most impactful)
+   - Then **Component Library** (reusable elements)
+   - Spacing, Animation, Input specs can be lighter passes
+
+3. **For each section, offer:**
+   - A) Fill in now — I'll ask specific questions
+   - B) Use defaults — I'll propose sensible defaults based on the game's genre and art style
+   - C) Skip — defer to later (flag as design debt)
+
+4. **After completing, write DESIGN.md** to the project's `docs/` directory.
+
+5. **Re-run Pass 5** — the new DESIGN.md now becomes the calibration source for all other passes.
+
+### Minimum Viable Design System
+
+If the user wants the fastest path, the minimum viable sections are:
+1. Art Direction (5 fields)
+2. Color Tokens (6 core tokens)
+3. Typography (3 levels: H1, Body, HUD)
+4. Buttons (2 variants: Primary, Secondary)
+
+Everything else can be deferred and built incrementally.

--- a/skills/plan-design-review/references/game-slop-patterns.md
+++ b/skills/plan-design-review/references/game-slop-patterns.md
@@ -1,0 +1,66 @@
+# Game UI Slop Patterns
+
+AI-generated and template-derived game UI patterns that signal "no design thinking happened here."
+When you encounter these in a plan, challenge them — not to remove them, but to make them SPECIFIC to this game.
+
+## The Slop Blacklist
+
+### HUD Slop
+| Pattern | Challenge Question |
+|---------|-------------------|
+| "Health bar" | What shape? What fill direction? What animation on damage? How does it reflect the game's identity? |
+| "Minimap in corner" | Does this game need a minimap? Would a compass, breadcrumbs, or environmental cues work better? |
+| "Ammo counter" | Number? Icons? Segmented bar? Does reload have a visual? Does low ammo change the display? |
+| "XP bar at bottom" | What makes earning XP feel satisfying in THIS game? Just a bar filling, or something specific? |
+| "Quest tracker on right" | How many quests shown? What happens at 10+ quests? Is there priority? Can player pin/unpin? |
+
+### Menu Slop
+| Pattern | Challenge Question |
+|---------|-------------------|
+| "Main menu with Play/Settings/Quit" | What's the visual theme? Is there a scene behind the menu? Does the menu reflect game progress? |
+| "Settings screen" | How many categories? What's the layout? Sliders or dropdowns? Preview for visual settings? |
+| "Loading screen with tips" | Tips about what? Are they contextual to where the player is going? Is there interactive content? |
+| "Pause menu overlay" | Darken? Blur? Can player still see game state? Is there a quick-resume option? |
+
+### Inventory & Shop Slop
+| Pattern | Challenge Question |
+|---------|-------------------|
+| "Grid-based inventory" | Why grid? Would a list, paper doll, or spatial system serve the game better? How do items show rarity? |
+| "Card-based shop" | Every F2P has card shops. What makes this one belong to THIS game? How does the player know what's worth buying? |
+| "Crafting UI" | Tree? Grid? Drag-and-drop? Discovery-based? How does the player learn recipes? What's the feedback on success? |
+| "Talent/skill tree" | Branching tree? Constellation? Grid? How does the player understand synergies? Is respec possible and how? |
+
+### Social & Multiplayer Slop
+| Pattern | Challenge Question |
+|---------|-------------------|
+| "Chat window" | Where? Always visible? Tabs for channels? Emoji/sticker support? Toxicity filtering visible to user? |
+| "Friend list" | How do players add friends? What status info is shown? Can you join a friend's game from the list? |
+| "Leaderboard" | Global? Friends? What time frame? What metric? How does rank #50,000 feel vs rank #5? |
+| "Lobby screen" | What can players DO while waiting? Is there a ready-up? Timer? Character preview? |
+
+### Onboarding Slop
+| Pattern | Challenge Question |
+|---------|-------------------|
+| "Tutorial tooltips" | Contextual or forced sequence? Dismissible? Visual or text-heavy? Do they teach by doing? |
+| "Press A to continue" | How many screens? Can the player skip? Is this information available later? |
+| "Highlight interactive objects" | What visual treatment? Glow? Outline? Particle? Does it match the art style or feel like a debug overlay? |
+
+## The Litmus Test
+
+**If you can describe a UI element in the plan using only generic terms and it still makes sense, it's slop.**
+
+Examples:
+- SLOP: "The inventory shows items in a grid with rarity colors."
+- SPECIFIC: "The inventory is a traveler's satchel that unfolds. Items are physical objects placed in compartments. Legendary items glow with the game's signature amber particle effect and emit a faint hum sound cue."
+
+- SLOP: "Health bar decreases when the player takes damage."
+- SPECIFIC: "The health system uses a cracked porcelain mask in the corner. Each hit adds visible cracks. At critical health, pieces fall off revealing darkness underneath. No numbers — players learn to read the mask."
+
+## Severity Classification
+
+| Severity | Description | Action |
+|----------|-------------|--------|
+| **CRITICAL** | Core loop UI is generic (HUD, main interaction) | Must redesign before implementation |
+| **HIGH** | Frequently seen UI is generic (inventory, shop, menus) | Should redesign — players will notice |
+| **MEDIUM** | Secondary UI is generic (settings, loading, tooltips) | Flag for polish pass |
+| **LOW** | Rare-use UI is generic (credits, achievements) | Acceptable to defer |

--- a/skills/plan-design-review/references/gotchas.md
+++ b/skills/plan-design-review/references/gotchas.md
@@ -1,0 +1,74 @@
+# Plan Design Review — Gotchas & Forcing Questions
+
+## Claude-Specific Failure Modes
+
+### Gotcha #1: Reviewing Implementation Instead of Plan
+**Symptom:** Claude starts suggesting code changes, component implementations, or CSS.
+**Rule:** This skill reviews and EDITS THE PLAN. No code. No implementation. If you're writing code, stop.
+
+### Gotcha #2: Rubber-Stamping Vague Plans
+**Symptom:** Rating a plan 7/10 when it says "clean UI with good UX" without any specifics.
+**Rule:** Vague descriptions score 0-3 on that dimension. "Clean UI" is not a design decision. Name the font, the spacing scale, the interaction pattern.
+
+### Gotcha #3: Inventing Design Decisions for the User
+**Symptom:** Claude fills in missing design details and presents them as the plan's content.
+**Rule:** If the plan doesn't specify it, rate that dimension low. Propose additions clearly marked as "PROPOSED ADDITION" — do not silently fill gaps.
+
+### Gotcha #4: Skipping Passes Because "The Plan Doesn't Have UI"
+**Symptom:** Claude skips passes because the plan focuses on gameplay mechanics.
+**Rule:** If the plan has ANY player-facing feature, it has UI implications. A "crafting system" without UI specs means someone will ship a default grid. Flag the gap.
+
+### Gotcha #5: Generic Design Recommendations
+**Symptom:** Claude recommends "add loading indicators" or "use consistent colors" without connecting to THIS game's identity.
+**Rule:** Every recommendation must reference the specific game, its pillars, and its audience. "Add a loading indicator" → "Add a loading indicator that matches the game's hand-drawn art style — animated sketch of the protagonist, not a spinner."
+
+### Gotcha #6: Treating All Passes as Equal Priority
+**Symptom:** Spending equal time on Design System (Pass 5) when Interaction States (Pass 2) has critical gaps.
+**Rule:** Priority order under time pressure: Step 0 > Pass 2 (Interaction States) > Pass 4 (AI Slop) > Pass 1 (Info Architecture) > Pass 3 (Player Journey) > others. Never skip Step 0, Pass 2, or Pass 4.
+
+## Forcing Questions (Use at Least 3 Per Review)
+
+### Q1: The 1-Second Combat Test
+"If the player only glances at the screen for 1 second during the most intense moment of gameplay, what do they see? Is that specified in the plan?"
+**Why:** Exposes missing HUD hierarchy and information architecture gaps.
+
+### Q2: The Legendary Drop on Full Inventory
+"Player's inventory is full and they pick up a legendary item. What does the UI do? Is that in the plan?"
+**Why:** Exposes missing interaction states for the most emotionally charged edge case.
+
+### Q3: The First Death Emotion
+"What does the player feel 3 seconds after their first death? What UI element supports that emotion? Is it specified?"
+**Why:** Exposes missing emotional arc design at the most critical frustration point.
+
+### Q4: The Genre Swap Test
+"If I replaced every game-specific noun with generic terms, would this plan work for ANY game in the genre?"
+**Why:** Exposes AI slop risk — plans that are too generic to produce a distinctive game.
+
+### Q5: The Settings Screen
+"What does the settings screen look like? How many options? What categories? Is audio separate from video?"
+**Why:** Settings screens are the most commonly deferred UI — and the first thing players judge quality by.
+
+### Q6: The Colorblind Test
+"Turn the game to grayscale. Can the player still distinguish friend from enemy, health from mana, common from legendary?"
+**Why:** Exposes color-only information design that excludes 8% of male players.
+
+## Anti-Sycophancy Protocol
+
+**FORBIDDEN — never say these or any paraphrase:**
+- "Great design plan!"
+- "This plan has strong foundations"
+- "The design direction is promising"
+- "Good use of design patterns"
+- "Players will love this"
+- "The UI sounds intuitive"
+- "Solid design decisions"
+
+**CALIBRATED ACKNOWLEDGMENT — say this instead:**
+- "Pass 2 went from 3/10 to 8/10 after adding interaction states for 12 features. Two features still missing error states."
+- "The plan specifies exact HUD priority for 4/6 screen elements. The remaining 2 default to P4 — verify that's intentional."
+- "FTUE emotional arc covers first 3 minutes. Session loop and D7 retention hook are unspecified."
+
+**PUSH-BACK CADENCE:**
+1. Push once: State the design gap with the player impact.
+2. Push again: "What happens when an engineer reaches this section of the plan? They'll either ask you or guess. Which is more expensive?"
+3. Escalate: "This plan will produce generic UI at implementation because [specific dimension] is unspecified."

--- a/skills/plan-design-review/references/interaction-states.md
+++ b/skills/plan-design-review/references/interaction-states.md
@@ -1,0 +1,77 @@
+# Game Interaction States — Coverage Matrix
+
+## Standard States (from web/app design)
+
+| State | Description | Game Example |
+|-------|-------------|--------------|
+| **LOADING** | Data or asset is being fetched/loaded | Entering a new zone, loading save, connecting to server |
+| **EMPTY** | No content to display | Empty inventory, no friends online, no quests available |
+| **ERROR** | Something failed | Network disconnect, save corruption, purchase failed |
+| **SUCCESS** | Action completed successfully | Item crafted, level completed, purchase confirmed |
+| **PARTIAL** | Incomplete data or mixed state | Partially downloaded DLC, some friends online |
+
+## Game-Specific States
+
+| State | Description | Game Example |
+|-------|-------------|--------------|
+| **DEATH** | Player character died/lost | Game over screen, respawn countdown, death recap |
+| **RESPAWN** | Returning to play after death | Spawn protection, re-entry animation, loadout selection |
+| **COOLDOWN** | Ability/action temporarily unavailable | Skill on cooldown, weapon reloading, potion timer |
+| **FULL** | Container/resource at capacity | Inventory full, max currency, squad full |
+| **LOCKED** | Content exists but is not yet accessible | Locked character, level requirement not met, paywall |
+| **MATCHMAKING** | Waiting for other players | Queue timer, estimated wait, cancel option |
+| **PAUSED** | Game state suspended | Pause overlay, resume prompt, in single-player only |
+| **DISCONNECTED** | Lost connection during play | Reconnect prompt, timeout counter, offline fallback |
+| **INSUFFICIENT** | Not enough resource for action | Can't afford item, not enough materials, energy depleted |
+| **TUTORIAL** | First-time encounter with feature | Guided interaction, contextual tooltip, practice mode |
+| **BUFFERED** | Action queued but not yet executed | Queued ability, pending trade, scheduled event |
+
+## Coverage Matrix Template
+
+Use this template during Pass 2. Fill in what the player SEES for each applicable state.
+Mark N/A for states that don't apply to a feature.
+
+```
+FEATURE           | LOADING | EMPTY | ERROR | SUCCESS | DEATH | COOLDOWN | FULL | LOCKED | DISCONNECTED
+------------------|---------|-------|-------|---------|-------|----------|------|--------|-------------
+Main HUD          |         |       |       |         | [?]   | [?]      |      |        | [?]
+Inventory         | [?]     | [?]   | [?]   | [?]     |       |          | [?]  | [?]    |
+Shop/Store        | [?]     | [?]   | [?]   | [?]     |       |          |      | [?]    | [?]
+Crafting          | [?]     | [?]   | [?]   | [?]     |       | [?]      |      | [?]    |
+Skill/Ability Bar |         |       |       | [?]     | [?]   | [?]      |      | [?]    |
+Quest/Mission     | [?]     | [?]   |       | [?]     |       |          |      | [?]    |
+Social/Friends    | [?]     | [?]   | [?]   |         |       |          | [?]  |        | [?]
+Matchmaking       | [?]     |       | [?]   | [?]     |       |          | [?]  |        | [?]
+Settings          | [?]     |       | [?]   | [?]     |       |          |      |        |
+Save/Load         | [?]     | [?]   | [?]   | [?]     |       |          |      |        |
+```
+
+## How to Evaluate
+
+For each `[?]` cell:
+1. Does the plan describe what the player SEES (not backend behavior)?
+2. Is the visual treatment specific to this game's art style?
+3. Does it include a recovery action (what can the player DO)?
+
+**Scoring:**
+- Each applicable `[?]` cell that is specified = +1
+- Each applicable `[?]` cell that is unspecified = 0
+- Coverage % = specified / total applicable
+
+**Thresholds:**
+| Coverage | Score |
+|----------|-------|
+| 90-100% | 9-10 |
+| 75-89% | 7-8 |
+| 50-74% | 5-6 |
+| 25-49% | 3-4 |
+| 0-24% | 0-2 |
+
+## Common Gaps (Check These First)
+
+1. **Death screen** — Most plans describe "game over" but not what the player sees, feels, or can do
+2. **Full inventory** — What happens to the pickup? Is the player warned before it's lost?
+3. **Network disconnect during gameplay** — What's preserved? What's lost? How does the player know?
+4. **Insufficient resources** — Does the UI show what's missing? Does it suggest how to get it?
+5. **First-time feature encounter** — Is there a guided experience or does the player figure it out?
+6. **Cooldown visualization** — Sweeping clock? Grayed out? Number countdown? All three?

--- a/skills/plan-design-review/references/scoring.md
+++ b/skills/plan-design-review/references/scoring.md
@@ -1,0 +1,102 @@
+# Plan Design Review — Scoring Model
+
+## The Fix-to-10 Method
+
+For each of the 7 passes, rate the plan 0-10 on that dimension.
+
+**Rating process:**
+1. **Rate:** Assign a score with one-sentence justification
+2. **Gap:** Explain what a 10 looks like for THIS plan
+3. **Fix:** Propose concrete edits to the plan
+4. **Re-rate:** After user accepts/rejects changes, re-score
+5. **Loop:** Repeat until 10 or user says "good enough, move on"
+
+## Per-Pass Scoring Rubric
+
+### Pass 1: Information Architecture (weight: 15%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | Every screen has explicit visual hierarchy (what player sees 1st/2nd/3rd). Screen flow diagram exists. HUD priority mapping matches game pillars |
+| 7-8 | Most screens have hierarchy defined. Some screens missing or vague |
+| 5-6 | Screen list exists but hierarchy is implicit or inconsistent |
+| 3-4 | Screens mentioned but no information priority defined |
+| 0-2 | Plan describes features without any screen-level thinking |
+
+### Pass 2: Interaction State Coverage (weight: 20%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | Every UI feature has all applicable states specified (loading, empty, error, death, cooldown, full, locked). Each state describes what the player SEES |
+| 7-8 | Core features have states covered. Secondary features missing some |
+| 5-6 | Happy path well-specified. Error/edge states partially covered |
+| 3-4 | Only success states described. Failures mentioned generically |
+| 0-2 | No state thinking — plan assumes everything works perfectly |
+
+### Pass 3: Player Journey & Emotional Arc (weight: 15%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | Full player emotion storyboard from FTUE to D30. Each moment has intended emotion + UI/UX supporting it. Time-horizon design applied (5-sec, 5-min, long-term) |
+| 7-8 | FTUE and core loop emotions designed. Later journey gaps |
+| 5-6 | Key moments identified (first death, first win) but emotional design is implicit |
+| 3-4 | Player journey described functionally, no emotional layer |
+| 0-2 | No consideration of player emotional experience |
+
+### Pass 4: AI Slop Risk (weight: 15%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | Every UI element has a specific reason to exist in THIS game. No generic descriptions. Each element answers "why this game and not any game" |
+| 7-8 | Most UI is game-specific. 1-2 elements still generic |
+| 5-6 | Mix of specific and generic. Some elements could be from any game in the genre |
+| 3-4 | Mostly generic descriptions. "Health bar," "inventory grid," "settings menu" without differentiation |
+| 0-2 | Plan reads like a template — swap the game name and it still works |
+
+### Pass 5: Design System Alignment (weight: 10%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | DESIGN.md exists or plan establishes: color tokens, typography scale, spacing grid, button styles, icon style, component library. New components fit the vocabulary |
+| 7-8 | Partial design system. Core tokens defined, some gaps |
+| 5-6 | Visual direction stated ("dark theme, pixel art UI") but no systematic tokens |
+| 3-4 | Inconsistent visual descriptions across screens |
+| 0-2 | No design system thinking. Each screen described independently |
+
+### Pass 6: Input Adaptation & Accessibility (weight: 15%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | All target input methods have explicit UI specs. A11y fully specified: colorblind, subtitles, difficulty assists, touch targets, keyboard nav |
+| 7-8 | Primary input method well-specified. Secondary and a11y partially covered |
+| 5-6 | One input method assumed. Some a11y mentioned |
+| 3-4 | Input method implied but not designed for. No a11y |
+| 0-2 | No platform or accessibility thinking |
+
+### Pass 7: Unresolved Design Decisions (weight: 10%)
+
+| Score | Description |
+|-------|-------------|
+| 9-10 | All design decisions either made or explicitly deferred with risk assessment. Zero ambiguity that will surprise implementation |
+| 7-8 | Most decisions made. 1-2 deferred with clear reasoning |
+| 5-6 | Key decisions made but several implicit assumptions |
+| 3-4 | Many unstated assumptions. Implementation will require design guesswork |
+| 0-2 | Plan is a feature list, not a design document |
+
+## Weighted Total Calculation
+
+```
+Plan Health Score =
+  (Pass1 × 0.15) + (Pass2 × 0.20) + (Pass3 × 0.15) +
+  (Pass4 × 0.15) + (Pass5 × 0.10) + (Pass6 × 0.15) + (Pass7 × 0.10)
+```
+
+## Score Interpretation
+
+| Range | Verdict | Meaning |
+|-------|---------|---------|
+| 8.0-10.0 | DESIGN-COMPLETE | Plan is ready for implementation. Run /prototype-slice-plan |
+| 6.0-7.9 | SOLID | Functional gaps exist but plan is implementable with some design decisions during build |
+| 4.0-5.9 | NEEDS WORK | Significant design gaps. Implementation will require frequent design guesswork |
+| 2.0-3.9 | MAJOR GAPS | Plan is a feature list, not a design document. Most UI decisions unmade |
+| 0.0-1.9 | NO DESIGN | Plan has no UI/UX thinking. Start from scratch or run /game-ux-review on existing designs |

--- a/skills/player-experience/SKILL.md
+++ b/skills/player-experience/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/playtest/SKILL.md
+++ b/skills/playtest/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/prototype-slice-plan/SKILL.md
+++ b/skills/prototype-slice-plan/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/shared/preamble.md
+++ b/skills/shared/preamble.md
@@ -87,6 +87,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction
@@ -173,8 +174,8 @@ done
 _PRIOR_SKILLS=""
 for pattern in "*-gdd-import-*" "*-concept-*" "*-game-review-*" "*-balance-review-*" \
                "*-direction-*" "*-player-exp-*" "*-eng-review-*" "*-pitch-review-*" \
-               "*-slice-plan-*" "*-impl-handoff-*" "*-impl-review-*" "*-feel-pass-*" \
-               "*-playability-*" "*-qa-*" "*-ship-*"; do
+               "*-plan-design-review-*" "*-slice-plan-*" "*-impl-handoff-*" "*-impl-review-*" \
+               "*-feel-pass-*" "*-playability-*" "*-qa-*" "*-ship-*"; do
   FOUND=$(ls -t $_PROJECTS_DIR/$pattern.md 2>/dev/null | head -1)
   [ -n "$FOUND" ] && _PRIOR_SKILLS="$_PRIOR_SKILLS $pattern" && echo "PRIOR: $FOUND"
 done
@@ -276,9 +277,10 @@ Present exactly ONE AskUserQuestion based on the classified state. Follow the 4-
 > B) **Player walkthrough** — simulate a player's first experience → `/player-experience`
 > C) **Plan the build** — scope a prototype or vertical slice → `/prototype-slice-plan`
 > D) **Check the pitch** — evaluate this as a pitch to publishers/investors → `/pitch-review`
-> E) **Something else** — tell me what you're trying to accomplish
+> E) **Design the UI plan** — define UI/UX decisions before building → `/plan-design-review`
+> F) **Something else** — tell me what you're trying to accomplish
 >
-> RECOMMENDATION: Choose A if no review has been done yet. The design review surfaces issues before you invest build time. Player Impact: 8/10.
+> RECOMMENDATION: Choose A if no review has been done yet. Choose E if the GDD exists but UI/UX decisions are vague or missing. Player Impact: 8/10.
 
 ### REVIEWED State
 
@@ -290,8 +292,9 @@ Present exactly ONE AskUserQuestion based on the classified state. Follow the 4-
 > B) **Review the direction** — strategic assessment before committing to build → `/game-direction`
 > C) **Address review findings** — go back and fix issues found in reviews → `/game-review` (re-run)
 > D) **Balance deep-dive** — economy and progression need specific attention → `/balance-review`
+> E) **Design plan review** — check if plan has complete UI/UX specs before building → `/plan-design-review`
 >
-> RECOMMENDATION: Choose A if reviews came back clean. Choose C if reviews flagged critical issues.
+> RECOMMENDATION: Choose A if reviews came back clean. Choose E if the plan lacks UI/UX detail. Choose C if reviews flagged critical issues.
 
 ### BUILDING State
 

--- a/skills/triage/SKILL.md.tmpl
+++ b/skills/triage/SKILL.md.tmpl
@@ -38,8 +38,8 @@ done
 _PRIOR_SKILLS=""
 for pattern in "*-gdd-import-*" "*-concept-*" "*-game-review-*" "*-balance-review-*" \
                "*-direction-*" "*-player-exp-*" "*-eng-review-*" "*-pitch-review-*" \
-               "*-slice-plan-*" "*-impl-handoff-*" "*-impl-review-*" "*-feel-pass-*" \
-               "*-playability-*" "*-qa-*" "*-ship-*"; do
+               "*-plan-design-review-*" "*-slice-plan-*" "*-impl-handoff-*" "*-impl-review-*" \
+               "*-feel-pass-*" "*-playability-*" "*-qa-*" "*-ship-*"; do
   FOUND=$(ls -t $_PROJECTS_DIR/$pattern.md 2>/dev/null | head -1)
   [ -n "$FOUND" ] && _PRIOR_SKILLS="$_PRIOR_SKILLS $pattern" && echo "PRIOR: $FOUND"
 done
@@ -141,9 +141,10 @@ Present exactly ONE AskUserQuestion based on the classified state. Follow the 4-
 > B) **Player walkthrough** — simulate a player's first experience → `/player-experience`
 > C) **Plan the build** — scope a prototype or vertical slice → `/prototype-slice-plan`
 > D) **Check the pitch** — evaluate this as a pitch to publishers/investors → `/pitch-review`
-> E) **Something else** — tell me what you're trying to accomplish
+> E) **Design the UI plan** — define UI/UX decisions before building → `/plan-design-review`
+> F) **Something else** — tell me what you're trying to accomplish
 >
-> RECOMMENDATION: Choose A if no review has been done yet. The design review surfaces issues before you invest build time. Player Impact: 8/10.
+> RECOMMENDATION: Choose A if no review has been done yet. Choose E if the GDD exists but UI/UX decisions are vague or missing. Player Impact: 8/10.
 
 ### REVIEWED State
 
@@ -155,8 +156,9 @@ Present exactly ONE AskUserQuestion based on the classified state. Follow the 4-
 > B) **Review the direction** — strategic assessment before committing to build → `/game-direction`
 > C) **Address review findings** — go back and fix issues found in reviews → `/game-review` (re-run)
 > D) **Balance deep-dive** — economy and progression need specific attention → `/balance-review`
+> E) **Design plan review** — check if plan has complete UI/UX specs before building → `/plan-design-review`
 >
-> RECOMMENDATION: Choose A if reviews came back clean. Choose C if reviews flagged critical issues.
+> RECOMMENDATION: Choose A if reviews came back clean. Choose E if the plan lacks UI/UX detail. Choose C if reviews flagged critical issues.
 
 ### BUILDING State
 

--- a/skills/unfreeze/SKILL.md
+++ b/skills/unfreeze/SKILL.md
@@ -95,6 +95,7 @@ After every Completion Summary, include a `Next Step:` block. Route based on sta
 Layer A (Design):
   /game-import → /game-review
   /game-ideation → /game-review
+  /game-review → /plan-design-review → /prototype-slice-plan
   /game-review → /player-experience → /balance-review
   /game-direction → /game-eng-review
   /pitch-review → /game-direction


### PR DESCRIPTION
## Summary

- Adds `/plan-design-review` as the 28th skill — fills the gap between `/game-review` (GDD completeness) and `/prototype-slice-plan` (what to build first)
- Ports gstack's proven Fix-to-10 methodology with full game-domain adaptation: 7 passes, 5 reference files, 815L generated
- Includes 4 key mechanisms from gstack: Outside Voices (Codex + Subagent parallel review), Hard Rejection Rules, TODOS.md design debt tracking, Plan File Review Report (writes back into plan)

## Changes

**New files (7):**
- `skills/plan-design-review/SKILL.md.tmpl` — main template
- `skills/plan-design-review/references/scoring.md` — 7-dimension weighted rubric
- `skills/plan-design-review/references/gotchas.md` — Claude failure modes + 6 forcing questions
- `skills/plan-design-review/references/game-slop-patterns.md` — game UI slop blacklist
- `skills/plan-design-review/references/interaction-states.md` — 11 game-specific state matrix
- `skills/plan-design-review/references/design-system-template.md` — DESIGN.md scaffold

**Modified files (3 source + 27 regenerated):**
- `skills/shared/preamble.md` — added pipeline route: `/game-review → /plan-design-review → /prototype-slice-plan`
- `skills/triage/SKILL.md.tmpl` — added routing options in DOCUMENTED and REVIEWED states
- All 27 SKILL.md files regenerated (preamble change)

## Test plan

- [x] `bun run build` — all 29 skills generate successfully (including new plan-design-review)
- [x] `bun test` — 11/11 tests pass
- [ ] Manual: run `/plan-design-review` on a game project with a plan file
- [ ] Manual: verify Codex parallel review triggers when `codex` CLI is available
- [ ] Manual: verify DESIGN.md creation flow in Pass 5 Path B

🤖 Generated with [Claude Code](https://claude.com/claude-code)