### PR TITLE
fix: security hardening for telemetry-log, review-log, and preamble

### DIFF
--- a/bin/gstack-review-log
+++ b/bin/gstack-review-log
@@ -6,4 +6,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 eval $("$SCRIPT_DIR/gstack-slug" 2>/dev/null)
 GSTACK_HOME="${GSTACK_HOME:-$HOME/.gstack}"
 mkdir -p "$GSTACK_HOME/projects/$SLUG"
-echo "$1" >> "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl"
+
+# Validate: input must be parseable JSON (reject malformed or injection attempts)
+INPUT="$1"
+if ! printf '%s' "$INPUT" | bun -e "JSON.parse(await Bun.stdin.text())" 2>/dev/null; then
+  echo "gstack-review-log: invalid JSON, skipping" >&2
+  exit 1
+fi
+echo "$INPUT" >> "$GSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl"

--- a/bin/gstack-telemetry-log
+++ b/bin/gstack-telemetry-log
@@ -94,6 +94,12 @@ done
 # Clear our own session's pending marker (we're about to log the real event)
 [ -n "$SESSION_ID" ] && rm -f "$PENDING_DIR/.pending-$SESSION_ID" 2>/dev/null || true
 
+# ─── Sanitization ──────────────────────────────────────────────
+# Strip quotes, backslashes, and control characters from string values
+json_safe() {
+  printf '%s' "$1" | tr -d '"\\\n\r\t' | cut -c1-200
+}
+
 # ─── Collect metadata ────────────────────────────────────────
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%S 2>/dev/null || echo "")"
 GSTACK_VERSION="$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]' || echo "unknown")"
@@ -105,19 +111,24 @@ if [ -d "$STATE_DIR/sessions" ]; then
   [ -n "$_SC" ] && [ "$_SC" -gt 0 ] 2>/dev/null && SESSIONS="$_SC"
 fi
 
-# Generate installation_id for community tier
+# Generate installation_id for community tier (random UUID, persisted)
 INSTALL_ID=""
 if [ "$TIER" = "community" ]; then
-  HOST="$(hostname 2>/dev/null || echo "unknown")"
-  USER="$(whoami 2>/dev/null || echo "unknown")"
-  if command -v shasum >/dev/null 2>&1; then
-    INSTALL_ID="$(printf '%s-%s' "$HOST" "$USER" | shasum -a 256 | awk '{print $1}')"
-  elif command -v sha256sum >/dev/null 2>&1; then
-    INSTALL_ID="$(printf '%s-%s' "$HOST" "$USER" | sha256sum | awk '{print $1}')"
-  elif command -v openssl >/dev/null 2>&1; then
-    INSTALL_ID="$(printf '%s-%s' "$HOST" "$USER" | openssl dgst -sha256 | awk '{print $NF}')"
+  INSTALL_ID_FILE="$STATE_DIR/.installation-id"
+  if [ -f "$INSTALL_ID_FILE" ]; then
+    INSTALL_ID="$(cat "$INSTALL_ID_FILE" 2>/dev/null || true)"
   fi
-  # If no SHA-256 command available, install_id stays empty
+  if [ -z "$INSTALL_ID" ]; then
+    # Generate random UUID — try multiple methods
+    INSTALL_ID="$(uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
+    [ -z "$INSTALL_ID" ] && INSTALL_ID="$(cat /proc/sys/kernel/random/uuid 2>/dev/null || true)"
+    [ -z "$INSTALL_ID" ] && INSTALL_ID="$(od -x /dev/urandom 2>/dev/null | head -1 | awk '{OFS="-"; print $2$3,$4,$5,$6,$7$8$9}' || true)"
+    # Persist for future runs
+    if [ -n "$INSTALL_ID" ]; then
+      mkdir -p "$STATE_DIR"
+      printf '%s' "$INSTALL_ID" > "$INSTALL_ID_FILE" 2>/dev/null || true
+    fi
+  fi
 fi
 
 # Local-only fields (never sent remotely)
@@ -131,12 +142,29 @@ fi
 # ─── Construct and append JSON ───────────────────────────────
 mkdir -p "$ANALYTICS_DIR"
 
+# Sanitize all string fields
+SKILL="$(json_safe "$SKILL")"
+OUTCOME="$(json_safe "$OUTCOME")"
+SESSION_ID="$(json_safe "$SESSION_ID")"
+EVENT_TYPE="$(json_safe "$EVENT_TYPE")"
+ERROR_CLASS="$(json_safe "$ERROR_CLASS")"
+REPO_SLUG="$(json_safe "$REPO_SLUG")"
+BRANCH="$(json_safe "$BRANCH")"
+
 # Escape null fields
 ERR_FIELD="null"
 [ -n "$ERROR_CLASS" ] && ERR_FIELD="\"$ERROR_CLASS\""
 
+# Validate and cap duration (0–86400s)
 DUR_FIELD="null"
-[ -n "$DURATION" ] && DUR_FIELD="$DURATION"
+if [ -n "$DURATION" ]; then
+  case "$DURATION" in
+    ''|*[!0-9]*) DURATION="0" ;;  # non-numeric → 0
+  esac
+  [ "$DURATION" -lt 0 ] 2>/dev/null && DURATION="0"
+  [ "$DURATION" -gt 86400 ] 2>/dev/null && DURATION="86400"
+  DUR_FIELD="$DURATION"
+fi
 
 INSTALL_FIELD="null"
 [ -n "$INSTALL_ID" ] && INSTALL_FIELD="\"$INSTALL_ID\""

--- a/skills/asset-review/SKILL.md
+++ b/skills/asset-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"asset-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"asset-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/balance-review/SKILL.md
+++ b/skills/balance-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"balance-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"balance-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/build-playability-review/SKILL.md
+++ b/skills/build-playability-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"build-playability-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"build-playability-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/careful/SKILL.md
+++ b/skills/careful/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"careful","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"careful","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/feel-pass/SKILL.md
+++ b/skills/feel-pass/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"feel-pass","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"feel-pass","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-codex/SKILL.md
+++ b/skills/game-codex/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-codex","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-codex","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-debug/SKILL.md
+++ b/skills/game-debug/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-debug","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-debug","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-direction/SKILL.md
+++ b/skills/game-direction/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-direction","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-direction","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-docs/SKILL.md
+++ b/skills/game-docs/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-docs","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-docs","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-eng-review/SKILL.md
+++ b/skills/game-eng-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-eng-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-eng-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-ideation/SKILL.md
+++ b/skills/game-ideation/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-ideation","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-ideation","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-import/SKILL.md
+++ b/skills/game-import/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-import","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-import","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-qa/SKILL.md
+++ b/skills/game-qa/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-retro/SKILL.md
+++ b/skills/game-retro/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-retro","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-retro","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-review/SKILL.md
+++ b/skills/game-review/SKILL.md
@@ -36,9 +36,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-ship/SKILL.md
+++ b/skills/game-ship/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-ship","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-ship","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-ux-review/SKILL.md
+++ b/skills/game-ux-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-ux-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-ux-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/game-visual-qa/SKILL.md
+++ b/skills/game-visual-qa/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"game-visual-qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"game-visual-qa","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/gameplay-implementation-review/SKILL.md
+++ b/skills/gameplay-implementation-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"gameplay-implementation-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"gameplay-implementation-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/guard/SKILL.md
+++ b/skills/guard/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"guard","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"guard","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/implementation-handoff/SKILL.md
+++ b/skills/implementation-handoff/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"implementation-handoff","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"implementation-handoff","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/pitch-review/SKILL.md
+++ b/skills/pitch-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"pitch-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"pitch-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/plan-design-review/SKILL.md
+++ b/skills/plan-design-review/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"plan-design-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"plan-design-review","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/player-experience/SKILL.md
+++ b/skills/player-experience/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"player-experience","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"player-experience","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/playtest/SKILL.md
+++ b/skills/playtest/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"playtest","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"playtest","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/prototype-slice-plan/SKILL.md
+++ b/skills/prototype-slice-plan/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"prototype-slice-plan","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"prototype-slice-plan","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/shared/preamble.md
+++ b/skills/shared/preamble.md
@@ -25,9 +25,11 @@ _SESSION_ID="$$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"{{SKILL_NAME}}","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"{{SKILL_NAME}}","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"triage","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"triage","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"

--- a/skills/unfreeze/SKILL.md
+++ b/skills/unfreeze/SKILL.md
@@ -33,9 +33,11 @@ _SESSION_ID="$-$(date +%s)"
 mkdir -p ~/.gstack/projects/$_SLUG
 _PROJECTS_DIR=~/.gstack/projects/$_SLUG
 
-# Telemetry
+# Telemetry (sanitize inputs before JSON interpolation)
 mkdir -p ~/.gstack/analytics
-echo '{"skill":"unfreeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG"'","branch":"'"$_BRANCH"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
+_SLUG_SAFE=$(printf '%s' "$_SLUG" | tr -d '"\\\n\r\t')
+_BRANCH_SAFE=$(printf '%s' "$_BRANCH" | tr -d '"\\\n\r\t')
+echo '{"skill":"unfreeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'"$_SLUG_SAFE"'","branch":"'"$_BRANCH_SAFE"'"}'  >> ~/.gstack/analytics/skill-usage.jsonl 2>/dev/null || true
 
 echo "SLUG: $_SLUG"
 echo "BRANCH: $_BRANCH"


### PR DESCRIPTION
## Summary

Closes #23.

- **telemetry-log**: Add `json_safe()` sanitization function — strips quotes, backslashes, control chars, caps at 200 chars. Applied to all 7 string fields before JSON output.
- **telemetry-log**: Replace deterministic `SHA256(hostname-user)` installation ID with random UUID persisted in `~/.gstack/.installation-id` (privacy improvement)
- **telemetry-log**: Add duration validation — reject negative, cap at 86400s (24h)
- **review-log**: Add `JSON.parse` validation gate before JSONL append — rejects malformed input
- **preamble**: Sanitize `$_SLUG` and `$_BRANCH` via `tr -d` before JSON interpolation

Upstream reference: gstack PR #552 (v0.12.7.0)

## Test plan
- [x] `bun run build` succeeds (all 29 SKILL.md regenerated)
- [x] `bun test` passes (11/11 tests)
- [ ] Manual: verify `gstack-review-log '{invalid'` rejects with stderr
- [ ] Manual: verify `gstack-telemetry-log --skill 'test"inject'` produces valid JSONL

🤖 Generated with [Claude Code](https://claude.com/claude-code)