### PR TITLE
feat: Genre/Market Landscape Awareness for game-ideation and game-direction

### DIFF
--- a/skills/game-direction/SKILL.md
+++ b/skills/game-direction/SKILL.md
@@ -3,6 +3,8 @@ name: game-direction
 description: "Game direction review from producer/creative director perspective. Challenges premises, evaluates scope, market positioning, and strategic alignment."
 user_invocable: true
 preamble-tier: 2
+allowed-tools:
+  - WebSearch
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun scripts/gen-skill-docs.ts -->
@@ -255,6 +257,72 @@ Before reviewing any details, challenge the premise itself. This is the most imp
 **Push until you hear:** A specific strategic rationale — not just "I'm passionate about it" (that's motivation, not strategy). "Mobile puzzle market is shifting toward AI-integrated play, our team shipped 2 puzzle games, and we have a working LLM integration from our last project" = strategic. "I've always wanted to make this game" = passion (valid, but not strategy).
 
 **STOP.** Wait for answer. Push once on vague answers.
+
+### 0A.5: Market Positioning Check
+
+The designer just told you "why this game, why now." Before accepting or challenging that answer, check what the market actually says.
+
+**Privacy gate — AskUserQuestion:**
+
+> **[Re-ground]** You said: *"{summary of 0A answer — their strategic rationale}"*. I want to verify the market timing claim with current data.
+>
+> **[Simplify]** I'd search for things like "[genre] market [platform] [year]" and "[genre] player trends" — generalized terms only, never your game's name or proprietary details.
+>
+> A) **Yes, check the market** — validate my timing claim
+> B) **Skip — keep this private** — challenge me with what you already know
+>
+> RECOMMENDATION: Choose A. "Why now?" is a market question. Market questions deserve market data, not just intuition.
+
+**STOP.** Wait for answer.
+
+**If A (search):**
+
+Search using generalized genre/platform terms only. Never search the user's specific game name or proprietary concept.
+
+WebSearch queries (run 2-3):
+- `"[genre] [platform] market [current year]"` — is this genre growing or declining on this platform?
+- `"[genre] game releases [current year]"` — how many competitors are launching?
+- `"[genre] player demographics trends"` — is the audience expanding or contracting?
+
+Read the top 2-3 results from each search.
+
+**If B (skip):** Note: "Search skipped — challenging with in-distribution knowledge only." Proceed to 0B.
+
+**If WebSearch is unavailable:** Note: "WebSearch unavailable — proceeding with in-distribution knowledge only." Proceed to 0B.
+
+#### Three-Layer Synthesis
+
+- **Layer 1 — Conventional Wisdom:** What does the industry assume about this genre/platform combination? What's the "obvious" take?
+- **Layer 2 — Current Data:** What do search results show about market timing, competitor density, audience trends?
+- **Layer 3 — Designer's Claim vs. Reality:** Does the designer's "why now" answer hold up against the data? Where does it align? Where does it contradict?
+
+#### Eureka Check
+
+If the data reveals something that contradicts or strongly validates the designer's timing claim:
+
+> **EUREKA:** The designer says [claim]. Market data shows [evidence]. This means [implication — either "the timing is even better than stated because..." or "the timing claim doesn't hold because..."].
+
+If no eureka: "Market data is consistent with the designer's rationale. Proceeding with premise challenge."
+
+#### Market Check Summary
+
+Present findings, then push back (or validate) the 0A answer with evidence:
+
+> **Market Positioning Check:**
+>
+> - **Your claim:** "{designer's why-now rationale}"
+> - **Market says:** [genre] on [platform] is [growing/stable/declining/oversaturated]
+> - **Competitor density:** [X recent releases in this space]
+> - **Audience trend:** [expanding/stable/contracting]
+> {If eureka: **EUREKA:** [the insight]}
+>
+> **My assessment:** [Does the "why now" hold up? Specific evidence for/against.]
+>
+> {If misalignment found: "Your rationale says [X] but market data shows [Y]. This doesn't kill the project, but the plan should account for [implication]."}
+>
+> Let's continue to asset leverage assessment.
+
+Proceed to 0B. No separate STOP needed here — this is an informational push-back, not a decision point.
 
 ### 0B. Existing Asset Leverage
 

--- a/skills/game-direction/SKILL.md.tmpl
+++ b/skills/game-direction/SKILL.md.tmpl
@@ -3,6 +3,8 @@ name: game-direction
 description: "Game direction review from producer/creative director perspective. Challenges premises, evaluates scope, market positioning, and strategic alignment."
 user_invocable: true
 preamble-tier: 2
+allowed-tools:
+  - WebSearch
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun scripts/gen-skill-docs.ts -->
@@ -96,6 +98,72 @@ Before reviewing any details, challenge the premise itself. This is the most imp
 **Push until you hear:** A specific strategic rationale — not just "I'm passionate about it" (that's motivation, not strategy). "Mobile puzzle market is shifting toward AI-integrated play, our team shipped 2 puzzle games, and we have a working LLM integration from our last project" = strategic. "I've always wanted to make this game" = passion (valid, but not strategy).
 
 **STOP.** Wait for answer. Push once on vague answers.
+
+### 0A.5: Market Positioning Check
+
+The designer just told you "why this game, why now." Before accepting or challenging that answer, check what the market actually says.
+
+**Privacy gate — AskUserQuestion:**
+
+> **[Re-ground]** You said: *"{summary of 0A answer — their strategic rationale}"*. I want to verify the market timing claim with current data.
+>
+> **[Simplify]** I'd search for things like "[genre] market [platform] [year]" and "[genre] player trends" — generalized terms only, never your game's name or proprietary details.
+>
+> A) **Yes, check the market** — validate my timing claim
+> B) **Skip — keep this private** — challenge me with what you already know
+>
+> RECOMMENDATION: Choose A. "Why now?" is a market question. Market questions deserve market data, not just intuition.
+
+**STOP.** Wait for answer.
+
+**If A (search):**
+
+Search using generalized genre/platform terms only. Never search the user's specific game name or proprietary concept.
+
+WebSearch queries (run 2-3):
+- `"[genre] [platform] market [current year]"` — is this genre growing or declining on this platform?
+- `"[genre] game releases [current year]"` — how many competitors are launching?
+- `"[genre] player demographics trends"` — is the audience expanding or contracting?
+
+Read the top 2-3 results from each search.
+
+**If B (skip):** Note: "Search skipped — challenging with in-distribution knowledge only." Proceed to 0B.
+
+**If WebSearch is unavailable:** Note: "WebSearch unavailable — proceeding with in-distribution knowledge only." Proceed to 0B.
+
+#### Three-Layer Synthesis
+
+- **Layer 1 — Conventional Wisdom:** What does the industry assume about this genre/platform combination? What's the "obvious" take?
+- **Layer 2 — Current Data:** What do search results show about market timing, competitor density, audience trends?
+- **Layer 3 — Designer's Claim vs. Reality:** Does the designer's "why now" answer hold up against the data? Where does it align? Where does it contradict?
+
+#### Eureka Check
+
+If the data reveals something that contradicts or strongly validates the designer's timing claim:
+
+> **EUREKA:** The designer says [claim]. Market data shows [evidence]. This means [implication — either "the timing is even better than stated because..." or "the timing claim doesn't hold because..."].
+
+If no eureka: "Market data is consistent with the designer's rationale. Proceeding with premise challenge."
+
+#### Market Check Summary
+
+Present findings, then push back (or validate) the 0A answer with evidence:
+
+> **Market Positioning Check:**
+>
+> - **Your claim:** "{designer's why-now rationale}"
+> - **Market says:** [genre] on [platform] is [growing/stable/declining/oversaturated]
+> - **Competitor density:** [X recent releases in this space]
+> - **Audience trend:** [expanding/stable/contracting]
+> {If eureka: **EUREKA:** [the insight]}
+>
+> **My assessment:** [Does the "why now" hold up? Specific evidence for/against.]
+>
+> {If misalignment found: "Your rationale says [X] but market data shows [Y]. This doesn't kill the project, but the plan should account for [implication]."}
+>
+> Let's continue to asset leverage assessment.
+
+Proceed to 0B. No separate STOP needed here — this is an informational push-back, not a decision point.
 
 ### 0B. Existing Asset Leverage
 

--- a/skills/game-ideation/SKILL.md
+++ b/skills/game-ideation/SKILL.md
@@ -3,6 +3,8 @@ name: game-ideation
 description: "Interactive game concept brainstorming. Structures raw ideas into Fantasy/Loop/Twist, challenges assumptions with forcing questions, and validates with Iceberg framework."
 user_invocable: true
 preamble-tier: 2
+allowed-tools:
+  - WebSearch
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun scripts/gen-skill-docs.ts -->
@@ -292,6 +294,79 @@ Use MDA backward — start from Aesthetics, not Mechanics:
 > C) I changed my mind — let me start over
 
 **STOP.** Wait for confirmation. The fantasy is the foundation. Don't build on a shaky one.
+
+---
+
+## Phase 1.5: Genre/Market Landscape Check
+
+Now that the fantasy is defined, check what the market looks like for this genre before designing the core loop. This is NOT full market research (that's Phase 5, Layer 3). This is a quick sanity check: how crowded is this space, and what are competitors doing?
+
+**Privacy gate — AskUserQuestion:**
+
+> **[Re-ground]** Your fantasy is: *"{fantasy statement from Phase 1}"*. Before designing the core loop, I want to check the current landscape for games in this space.
+>
+> **[Simplify]** I'd search for things like "[genre] games 2026" and "[core mechanic] game market" — generalized terms, never your specific concept name or proprietary ideas.
+>
+> A) **Yes, search away** — check what's out there
+> B) **Skip — keep this private** — I'll work from what I already know
+>
+> RECOMMENDATION: Choose A unless this concept is under NDA or stealth. Knowing the landscape costs 2 minutes and can save months of building something the market already has.
+
+**STOP.** Wait for answer.
+
+**If A (search):**
+
+Search using generalized genre/mechanic terms only. Never search the user's specific game name or proprietary concept.
+
+WebSearch queries (run 2-3):
+- `"[genre from fantasy] games [current year]"` — what's launching, what's trending
+- `"[core mechanic] [genre] game market"` — competitor density and saturation
+- `"[genre] indie game [current year]"` — what the indie landscape looks like (scope-appropriate comps)
+
+Read the top 2-3 results from each search.
+
+**If B (skip):** Note: "Search skipped — proceeding with in-distribution knowledge only." Move directly to Phase 2.
+
+**If WebSearch is unavailable:** Note: "WebSearch unavailable — proceeding with in-distribution knowledge only." Move directly to Phase 2.
+
+### Three-Layer Synthesis
+
+After reading search results, synthesize:
+
+- **Layer 1 — Conventional Wisdom:** What does everyone already know about this genre? What are the established patterns, the "obvious" design choices, the things every game in this space does?
+- **Layer 2 — Current Landscape:** What do the search results show? How many recent games target this space? What mechanics are trending? What's oversaturated? What gaps exist?
+- **Layer 3 — Differentiation Reality:** Given the designer's fantasy from Phase 1 — does it stand out from what's already out there? Or is it "zombie survival game #47"?
+
+### Eureka Check
+
+If Layer 3 reveals genuine differentiation — something the market hasn't tried, or an assumption everyone makes that might be wrong — flag it:
+
+> **EUREKA:** Everyone in [genre] does [X] because they assume [assumption]. But [evidence from search + designer's fantasy] suggests that's wrong. This means [implication for core loop design].
+
+If no eureka moment exists: "The conventional wisdom in this genre is well-established. Your differentiation needs to come from execution or a specific twist in Phase 3."
+
+### Landscape Summary
+
+Present to the user via AskUserQuestion:
+
+> **Genre/Market Snapshot:**
+>
+> - **Genre health:** [growing / stable / declining / oversaturated]
+> - **Recent competitors:** [2-3 games with release year]
+> - **Common pattern:** [what most games in this space do]
+> - **Gap or opportunity:** [what's missing or underserved]
+> {If eureka: **EUREKA:** [the insight]}
+>
+> **What this means for your core loop:**
+> [1-2 sentences about how this should influence Phase 2 design]
+>
+> A) **Proceed to Core Loop** — this landscape informs our design
+> B) **Reconsider the fantasy** — the landscape changes my thinking
+> C) **Search for something more specific** — I want to look at [topic]
+>
+> RECOMMENDATION: {based on findings}
+
+**STOP.** Wait for answer. If B, return to Phase 1. If C, run one more targeted search, then re-present.
 
 ---
 

--- a/skills/game-ideation/SKILL.md.tmpl
+++ b/skills/game-ideation/SKILL.md.tmpl
@@ -3,6 +3,8 @@ name: game-ideation
 description: "Interactive game concept brainstorming. Structures raw ideas into Fantasy/Loop/Twist, challenges assumptions with forcing questions, and validates with Iceberg framework."
 user_invocable: true
 preamble-tier: 2
+allowed-tools:
+  - WebSearch
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun scripts/gen-skill-docs.ts -->
@@ -133,6 +135,79 @@ Use MDA backward — start from Aesthetics, not Mechanics:
 > C) I changed my mind — let me start over
 
 **STOP.** Wait for confirmation. The fantasy is the foundation. Don't build on a shaky one.
+
+---
+
+## Phase 1.5: Genre/Market Landscape Check
+
+Now that the fantasy is defined, check what the market looks like for this genre before designing the core loop. This is NOT full market research (that's Phase 5, Layer 3). This is a quick sanity check: how crowded is this space, and what are competitors doing?
+
+**Privacy gate — AskUserQuestion:**
+
+> **[Re-ground]** Your fantasy is: *"{fantasy statement from Phase 1}"*. Before designing the core loop, I want to check the current landscape for games in this space.
+>
+> **[Simplify]** I'd search for things like "[genre] games 2026" and "[core mechanic] game market" — generalized terms, never your specific concept name or proprietary ideas.
+>
+> A) **Yes, search away** — check what's out there
+> B) **Skip — keep this private** — I'll work from what I already know
+>
+> RECOMMENDATION: Choose A unless this concept is under NDA or stealth. Knowing the landscape costs 2 minutes and can save months of building something the market already has.
+
+**STOP.** Wait for answer.
+
+**If A (search):**
+
+Search using generalized genre/mechanic terms only. Never search the user's specific game name or proprietary concept.
+
+WebSearch queries (run 2-3):
+- `"[genre from fantasy] games [current year]"` — what's launching, what's trending
+- `"[core mechanic] [genre] game market"` — competitor density and saturation
+- `"[genre] indie game [current year]"` — what the indie landscape looks like (scope-appropriate comps)
+
+Read the top 2-3 results from each search.
+
+**If B (skip):** Note: "Search skipped — proceeding with in-distribution knowledge only." Move directly to Phase 2.
+
+**If WebSearch is unavailable:** Note: "WebSearch unavailable — proceeding with in-distribution knowledge only." Move directly to Phase 2.
+
+### Three-Layer Synthesis
+
+After reading search results, synthesize:
+
+- **Layer 1 — Conventional Wisdom:** What does everyone already know about this genre? What are the established patterns, the "obvious" design choices, the things every game in this space does?
+- **Layer 2 — Current Landscape:** What do the search results show? How many recent games target this space? What mechanics are trending? What's oversaturated? What gaps exist?
+- **Layer 3 — Differentiation Reality:** Given the designer's fantasy from Phase 1 — does it stand out from what's already out there? Or is it "zombie survival game #47"?
+
+### Eureka Check
+
+If Layer 3 reveals genuine differentiation — something the market hasn't tried, or an assumption everyone makes that might be wrong — flag it:
+
+> **EUREKA:** Everyone in [genre] does [X] because they assume [assumption]. But [evidence from search + designer's fantasy] suggests that's wrong. This means [implication for core loop design].
+
+If no eureka moment exists: "The conventional wisdom in this genre is well-established. Your differentiation needs to come from execution or a specific twist in Phase 3."
+
+### Landscape Summary
+
+Present to the user via AskUserQuestion:
+
+> **Genre/Market Snapshot:**
+>
+> - **Genre health:** [growing / stable / declining / oversaturated]
+> - **Recent competitors:** [2-3 games with release year]
+> - **Common pattern:** [what most games in this space do]
+> - **Gap or opportunity:** [what's missing or underserved]
+> {If eureka: **EUREKA:** [the insight]}
+>
+> **What this means for your core loop:**
+> [1-2 sentences about how this should influence Phase 2 design]
+>
+> A) **Proceed to Core Loop** — this landscape informs our design
+> B) **Reconsider the fantasy** — the landscape changes my thinking
+> C) **Search for something more specific** — I want to look at [topic]
+>
+> RECOMMENDATION: {based on findings}
+
+**STOP.** Wait for answer. If B, return to Phase 1. If C, run one more targeted search, then re-present.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #24.

Adds WebSearch-based genre/market landscape checks to two design skills:

### `/game-ideation` — Phase 1.5: Genre/Market Landscape Check
- Inserted after Phase 1 (Fantasy definition), before Phase 2 (Core Loop)
- Privacy gate: asks before searching, uses generalized terms only
- Three-layer synthesis: conventional wisdom → search results → differentiation reality
- Eureka check for genuine market insights
- Decision point: proceed / reconsider fantasy / search more

### `/game-direction` — Phase 0A.5: Market Positioning Check
- Inserted after 0A ("Why this game, why now?"), before 0B (Asset Leverage)
- Validates the designer's market timing claim with current data
- Same privacy gate + three-layer synthesis + eureka check
- Informational push-back (not a decision gate)

Both skills get `allowed-tools: [WebSearch]` in frontmatter. Graceful degradation when WebSearch is unavailable.

Upstream reference: gstack office-hours Phase 2.75 Landscape Awareness

## Test plan
- [x] `bun run build` succeeds
- [x] `bun test` passes (14/14)
- [x] Phase 1.5 appears between Phase 1 and Phase 2 in game-ideation
- [x] Phase 0A.5 appears between 0A and 0B in game-direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)