### PR TITLE
fix: gstack-slug non-git fallback — prevent crash outside git repos

### DIFF
--- a/bin/gstack-slug
+++ b/bin/gstack-slug
@@ -2,8 +2,17 @@
 # gstack-slug — output project slug and sanitized branch name
 # Usage: source <(gstack-slug)  → sets SLUG and BRANCH variables
 # Or:    gstack-slug           → prints SLUG=... and BRANCH=... lines
+#
+# Security: output is sanitized to [a-zA-Z0-9._-] only, preventing
+# shell injection when consumed via source or eval.
 set -euo pipefail
-SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-')
+RAW_SLUG=$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-') || true
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-') || true
+# Strip any characters that aren't alphanumeric, dot, hyphen, or underscore
+SLUG=$(printf '%s' "${RAW_SLUG:-}" | tr -cd 'a-zA-Z0-9._-')
+BRANCH=$(printf '%s' "${RAW_BRANCH:-}" | tr -cd 'a-zA-Z0-9._-')
+# Fallback when git context is absent
+SLUG="${SLUG:-$(basename "$PWD" | tr -cd 'a-zA-Z0-9._-')}"
+BRANCH="${BRANCH:-unknown}"
 echo "SLUG=$SLUG"
 echo "BRANCH=$BRANCH"


### PR DESCRIPTION
## Summary
Closes #34.

Port upstream gstack-slug fix: fallback to dirname/"unknown" when git context is absent, plus output sanitization to prevent shell injection.

## Test plan
- [x] `bun test` passes (14/14)
- [ ] Manual: run `gstack-slug` in a non-git directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)