### PR TITLE
feat: add User Sovereignty principle to preamble

### DIFF
--- a/skills/asset-review/SKILL.md
+++ b/skills/asset-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/balance-review/SKILL.md
+++ b/skills/balance-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/build-playability-review/SKILL.md
+++ b/skills/build-playability-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/careful/SKILL.md
+++ b/skills/careful/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/feel-pass/SKILL.md
+++ b/skills/feel-pass/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-codex/SKILL.md
+++ b/skills/game-codex/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-debug/SKILL.md
+++ b/skills/game-debug/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-direction/SKILL.md
+++ b/skills/game-direction/SKILL.md
@@ -63,6 +63,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-docs/SKILL.md
+++ b/skills/game-docs/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-eng-review/SKILL.md
+++ b/skills/game-eng-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-ideation/SKILL.md
+++ b/skills/game-ideation/SKILL.md
@@ -63,6 +63,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-import/SKILL.md
+++ b/skills/game-import/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-qa/SKILL.md
+++ b/skills/game-qa/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-retro/SKILL.md
+++ b/skills/game-retro/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-review/SKILL.md
+++ b/skills/game-review/SKILL.md
@@ -64,6 +64,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.
@@ -382,10 +389,10 @@ Cross-Model Synthesis:
 ═══════════════════════════════════════════
 ```
 
-Then 3-5 bullet synthesis:
-- Where the primary review agrees with the second opinion
-- Where it disagrees and why
-- Whether any challenged premise changes the Section 1 assessment
+Then 3-5 bullet synthesis — present both perspectives neutrally:
+- Where the primary review and second opinion agree
+- Where they diverge, with each side's reasoning
+- Any challenged premises the user should weigh before proceeding
 
 ### Premise Revision Check:
 

--- a/skills/game-review/SKILL.md.tmpl
+++ b/skills/game-review/SKILL.md.tmpl
@@ -223,10 +223,10 @@ Cross-Model Synthesis:
 ═══════════════════════════════════════════
 ```
 
-Then 3-5 bullet synthesis:
-- Where the primary review agrees with the second opinion
-- Where it disagrees and why
-- Whether any challenged premise changes the Section 1 assessment
+Then 3-5 bullet synthesis — present both perspectives neutrally:
+- Where the primary review and second opinion agree
+- Where they diverge, with each side's reasoning
+- Any challenged premises the user should weigh before proceeding
 
 ### Premise Revision Check:
 

--- a/skills/game-ship/SKILL.md
+++ b/skills/game-ship/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-ux-review/SKILL.md
+++ b/skills/game-ux-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/game-visual-qa/SKILL.md
+++ b/skills/game-visual-qa/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/gameplay-implementation-review/SKILL.md
+++ b/skills/gameplay-implementation-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/guard/SKILL.md
+++ b/skills/guard/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/implementation-handoff/SKILL.md
+++ b/skills/implementation-handoff/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/pitch-review/SKILL.md
+++ b/skills/pitch-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/plan-design-review/SKILL.md
+++ b/skills/plan-design-review/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/player-experience/SKILL.md
+++ b/skills/player-experience/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/playtest/SKILL.md
+++ b/skills/playtest/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/prototype-slice-plan/SKILL.md
+++ b/skills/prototype-slice-plan/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/shared/preamble-core.md
+++ b/skills/shared/preamble-core.md
@@ -52,6 +52,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.

--- a/skills/unfreeze/SKILL.md
+++ b/skills/unfreeze/SKILL.md
@@ -61,6 +61,13 @@ All skills read from this directory on startup to find prior work. All skills wr
 
 If `PROACTIVE` is `"false"`, do not proactively suggest gstack-game skills.
 
+## User Sovereignty
+
+AI models recommend. You decide. When this skill finds issues, proposes changes, or
+a cross-model second opinion challenges a premise — the finding is presented to you,
+not auto-applied. Cross-model agreement is a strong signal, not a mandate. Your
+direction is the default unless you explicitly change it.
+
 ## Completion Status Protocol
 
 DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT.


### PR DESCRIPTION
## Summary
Closes #33.
- User Sovereignty section in preamble-core.md (all 28+ skills, all tiers)
- game-review Phase 1.5 synthesis updated to present both perspectives neutrally

Upstream reference: gstack PR #603 (v0.13.2.0)

## Test plan
- [x] `bun run build` succeeds
- [x] `bun test` passes (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)